### PR TITLE
Notify on failed deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,4 +19,9 @@ pipeline {
       }
     }
   }
+  post {
+    failure {
+      step([$class: 'GitHubIssueNotifier'])
+    }
+  }
 }


### PR DESCRIPTION
https://github.com/GSA/datagov-ckan-multi/issues/287

This creates a new GH issue when the deployment fails so that an action can be taken to correct it.