### PR TITLE
"Hotfix" to update requirements-freeze.txt to include theme deps

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -1,121 +1,87 @@
-alabaster==0.7.12
-asn1crypto==0.24.0
-Babel==2.3.4
-Beaker==1.9.0
-beautifulsoup4==4.5.1
+-i https://pypi.org/simple
+-e git+https://github.com/GSA/ckanext-datajson.git@46ed53e6bfa3ad1f60bda06daba8fdf77138b254#egg=ckanext-datajson
+argparse==1.4.0
+asn1crypto==1.3.0
+babel==2.3.4
+beaker==1.11.0
 bleach==2.1.3
-blinker==1.4
 boto==2.49.0
-certifi==2019.6.16
 cffi==1.12.3
--e git+https://github.com/ckan/ckan.git@8e1cc60b2fa11da6843051678b7ee2cc08c2a7a9#egg=ckan
--e git+https://github.com/GSA/ckanext-datagovtheme.git@873dc70135d4ed313517010fb2b3c208b72c2913#egg=ckanext_datagovtheme
--e git+https://github.com/GSA/ckanext-datajson.git@46ed53e6bfa3ad1f60bda06daba8fdf77138b254#egg=ckanext_datajson
--e git+https://github.com/okfn/ckanext-envvars.git@8602376a92a77b4f2d41763b6823d041469fa08e#egg=ckanext_envvars
--e git+https://github.com/GSA/ckanext-geodatagov.git@d82eb45067f9b8335b6d767499f218431fb6c215#egg=ckanext_geodatagov
--e git+https://github.com/ckan/ckanext-harvest.git@6d286eb8fd6ea3a136f0f3293b29efd5b4fbc025#egg=ckanext_harvest
--e git+https://github.com/ckan/ckanext-spatial@4ac25f19aa4eb9c798451f5eeb3084f907ccc003#egg=ckanext_spatial
+ckanext-envvars==0.0.1
 ckantoolkit==0.0.3
 click==6.7
-coverage==4.5.3
-coveralls==1.8.1
-cryptography==2.7
-decorator==4.2.1
-docopt==0.6.2
-docutils==0.12
-enum34==1.1.6
-extras==1.0.0
-factory-boy==2.1.1
+decorator==4.4.2
+enum34==1.1.10; python_version < '3'
 fanstatic==0.12
-first==2.0.2
-fixtures==3.0.0
-Flask==0.12.4
-Flask-Babel==0.11.2
-Flask-DebugToolbar==0.10.1
-FormEncode==1.3.1
+flask-babel==0.11.2
+flask==0.12.4
+formencode==1.3.1
 funcsigs==1.0.2
-GeoAlchemy==0.7.2
-GeoAlchemy2==0.5.0
-gevent==1.2.2
-greenlet==0.4.12
+geoalchemy2==0.5.0
+geoalchemy==0.7.2
+git+https://github.com/GSA/ckanext-datagovtheme.git@873dc70135d4ed313517010fb2b3c208b72c2913#egg=ckanext-datagovtheme
+git+https://github.com/GSA/ckanext-geodatagov.git@d82eb45067f9b8335b6d767499f218431fb6c215#egg=ckanext-geodatagov
+git+https://github.com/asl2/PyZ3950.git@c2282c73182cef2beca0f65b1eb7699c9b24512e#egg=pyz3950
+git+https://github.com/ckan/ckan.git@7900935de6270ee80ec64a5378251dafedf3a0e4#egg=ckan
+git+https://github.com/ckan/ckanext-harvest.git@6d286eb8fd6ea3a136f0f3293b29efd5b4fbc025#egg=ckanext-harvest
+git+https://github.com/ckan/ckanext-spatial@4ac25f19aa4eb9c798451f5eeb3084f907ccc003#egg=ckanext-spatial
+gunicorn==19.10.0
 html5lib==1.0.1
-httpretty==0.8.3
-idna==2.8
-imagesize==1.1.0
-ipaddress==1.0.22
-itsdangerous==0.24
-Jinja2==2.8
+ipaddress==1.0.23; python_version < '3'
+itsdangerous==1.1.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+jinja2==2.8
 jsonschema==2.4.0
-LEPL==5.1.3
-linecache2==1.0.0
-lxml==4.5.0
-Mako==1.0.7
-Markdown==2.6.7
-MarkupSafe==1.0
-meld3==1.0.2
-mock==2.0.0
-mox3==0.27.0
+lepl==5.1.3
+lxml==4.5.1
+mako==1.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+markdown==3.1.1
+markupsafe==1.1.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 nose==1.3.7
 ofs==0.4.2
-OWSLib==0.8.6
-packaging==19.0
-Pairtree===0.7.1-T
+owslib==0.8.6
+pairtree==0.7.1-T
 passlib==1.6.5
-Paste==1.7.5.1
-PasteDeploy==1.5.2
-PasteScript==2.0.2
+paste==1.7.5.1
+pastedeploy==2.1.0
+pastescript==2.0.2
 pbr==1.10.0
 pika==1.1.0
-pip-tools==1.7.0
 ply==3.4
 polib==1.0.7
 psycopg2==2.7.3.2
-pycodestyle==2.2.0
-pycparser==2.19
-pyfakefs==2.9
-Pygments==2.2.0
-Pylons==0.9.7
-pyOpenSSL==18.0.0
-pyparsing==2.4.0
+pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pygments==2.5.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pylons==0.9.7
+pyopenssl==18.0.0
+pyparsing==2.4.7
 pysolr==3.6.0
 python-dateutil==1.5
 python-magic==0.4.15
-python-mimeparse==1.6.0
 pytz==2016.7
 pyutilib.component.core==4.6.4
-PyYAML==5.3.1
--e git+https://github.com/asl2/PyZ3950.git@c2282c73182cef2beca0f65b1eb7699c9b24512e#egg=PyZ3950
-redis==3.5.1
+pyyaml==5.3.1
+redis==3.5.2
 repoze.lru==0.7
-repoze.who==2.3
 repoze.who-friendlyform==1.0.8
+repoze.who==2.3
+requests==2.11.1
 rfc3987==1.3.8
-Routes==1.13
+routes==1.13
 rq==0.6.0
-Shapely==1.7.0
+shapely==1.7.0
 simplejson==3.10.0
-six==1.11.0
-snowballstemmer==1.9.0
-Sphinx==1.7.1
-sphinx-rtd-theme==0.3.1
-sphinxcontrib-websupport==1.1.2
-SQLAlchemy==1.1.11
+six==1.14.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sqlalchemy-migrate==0.10.0
+sqlalchemy==1.1.11
 sqlparse==0.2.2
-supervisor==4.0.3
-Tempita==0.5.2
-testtools==2.3.0
-traceback2==1.4.0
-typing==3.7.4
+tempita==0.5.2
 tzlocal==1.3
 unicodecsv==0.14.1
-unittest2==1.1.0
-urllib3==1.24.3
 vdm==0.14
 webencodings==0.5.1
-WebError==0.13.1
-WebHelpers==1.3
-WebOb==1.0.8
-WebTest==1.4.3
-Werkzeug==0.14.1
+weberror==0.13.1
+webhelpers==1.3
+webob==1.0.8
+webtest==1.4.3
+werkzeug==0.14.1
 zope.interface==4.3.2


### PR DESCRIPTION
Per our technical sync-up on 5/19, here is the hotfix to update the requirements-freeze.txt file to add the datagov theme and dependencies.

(This is just temporary until https://github.com/GSA/catalog.data.gov/pull/22 is in use.)