### PR TITLE
Fixes bug on dataset page caused by a configuration missing 

### DIFF
--- a/.env
+++ b/.env
@@ -49,3 +49,6 @@ CKAN__HARVEST__MQ__PORT=6379
 CKAN__HARVEST__MQ__REDIS_DB=1
 CKAN__HARVEST__LOG_LEVEL=info
 CKAN__HARVEST__LOG_SCOPE=0
+
+CKANEXT__GEODATAGOV__BUREAU_CSV__URL=https://project-open-data.cio.gov/data/omb_bureau_codes.csv
+

--- a/.env
+++ b/.env
@@ -51,4 +51,4 @@ CKAN__HARVEST__LOG_LEVEL=info
 CKAN__HARVEST__LOG_SCOPE=0
 
 CKANEXT__GEODATAGOV__BUREAU_CSV__URL=https://project-open-data.cio.gov/data/omb_bureau_codes.csv
-
+CKANEXT__GEODATAGOV__BUREAU_CSV__URL_DEFAULT=https://project-open-data.cio.gov/data/omb_bureau_codes.csv


### PR DESCRIPTION
Fixes [#19](https://github.com/GSA/catalog.data.gov/issues/19) 

Add configuration for bureau codes used by datagovtheme