### PR TITLE
bats-support for testing sugar

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,8 +1,20 @@
-FROM bats/bats
+FROM bash as bats
 
-RUN apk add curl jq postgresql-client
+RUN apk add git && \
+  mkdir /bats && \
+  git clone https://github.com/bats-core/bats-core.git /bats && \
+  git clone https://github.com/bats-core/bats-support.git /bats/lib/bats-support && \
+  git clone https://github.com/bats-core/bats-assert.git /bats/lib/bats-assert
+
+FROM bash
+
+RUN apk add curl jq ncurses parallel postgresql-client
+
+COPY --from=bats /bats/ /bats/
+
+RUN ln -s /bats/bin/bats /usr/local/bin/bats
 
 COPY tests/ /tests/
 
-# bats/bats uses bats as the entrypoint
-CMD ["-r", "/tests"]
+ENTRYPOINT ["bash", "/usr/local/bin/bats"]
+CMD ["-p", "-r", "/tests"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -17,4 +17,4 @@ RUN ln -s /bats/bin/bats /usr/local/bin/bats
 COPY tests/ /tests/
 
 ENTRYPOINT ["bash", "/usr/local/bin/bats"]
-CMD ["-p", "-r", "/tests"]
+CMD ["-r", "/tests"]

--- a/tests/helpers.bats
+++ b/tests/helpers.bats
@@ -5,12 +5,55 @@
 
 load test_helper
 
-@test "when I log with arguments then the arguments are printed to stderr" {
+@test 'when log called with arguments then the arguments are printed to stderr' {
   output=$(log "a" "b" 2>&1 > /dev/null)
   assert_output "a b"
 }
 
-@test "when I log with stdin then stdin is printed to stderr" {
+@test 'when log called with stdin then stdin is printed to stderr' {
   output=$(echo a b | log 2>&1 > /dev/null)
   assert_output "a b"
+}
+
+@test 'given json with match when assert_json called then success' {
+  run echo '{"name": "fred"}'
+  run assert_json .name fred
+
+  test "$status" -eq 0
+  test "${#lines[@]}" -eq 0
+}
+
+@test 'given json without match when assert_json called then failure' {
+  run echo '{"name": "fred"}'
+  run assert_json .name bob
+
+  expected=$(cat <<EOF
+selector : .name
+actual   : fred
+expected : bob
+output   : {"name": "fred"}
+EOF
+)
+
+  test "$status" -eq 1
+  test "$output" == "$expected"
+}
+
+@test 'given invalid json when assert_json called then failure' {
+  run echo not json
+  run assert_json .name fred
+
+  log "$output"
+  # Watch out for the trailing space in expected output
+  expected=$(cat <<EOF
+parse error: Invalid literal at line 1, column 4
+selector : .name
+actual   : 
+expected : fred
+output   : not json
+EOF
+)
+
+  test "$status" -eq 1
+  test "$output" == "$expected"
 }

--- a/tests/helpers.bats
+++ b/tests/helpers.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+#
+# Test the test helpers in test_helper.bash
+#
+
+load test_helper
+
+@test "when I log with arguments then the arguments are printed to stderr" {
+  output=$(log "a" "b" 2>&1 > /dev/null)
+  assert_output "a b"
+}
+
+@test "when I log with stdin then stdin is printed to stderr" {
+  output=$(echo a b | log 2>&1 > /dev/null)
+  assert_output "a b"
+}

--- a/tests/test-base.bats
+++ b/tests/test-base.bats
@@ -25,7 +25,7 @@ load test_helper
     --data "password=$CKAN_SYSADMIN_PASSWORD" \
     --cookie-jar $BATS_TMPDIR/cookie-jar 2>&1 > /dev/null)
 
-  echo "$output" >&2 # debug
+  log "$output"
   echo "$output" | grep -qi '^< set-cookie:.*auth_tkt'
 }
 
@@ -38,7 +38,7 @@ load test_helper
     --data 'login=not_a_user' \
     --data 'password=badpassword' 2>&1 >/dev/null)
 
-  echo "$output" >&2 # debug
+  log "$output"
   ! echo "$output" | grep -qi '^< set-cookie:.*auth_tkt'
 }
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -24,6 +24,17 @@ output   : $output
 EOF
 }
 
+# db [psql-args]
+#
+# stdin: SQL
+#
+# Wrapper for psql (defaults to ckan DB) for better shell support. A SQL error
+# will cause psql to error. Removes headers and column delimiters from the
+# output format for better parsing of the query response.
+function db () {
+  PGPASSWORD=ckan psql --no-align --quiet --tuples-only --set ON_ERROR_STOP=1 --host db --user ckan "$@"
+}
+
 # log <msg>...
 #
 # stdin: msg
@@ -63,16 +74,12 @@ function wait_for_app () {
   retries=15
   local len_api_key=0
   
-  export PGPASSWORD=$CKAN_DB_PW
-
   while [ $len_api_key -le 10 ]; do
-    local sql_command="psql -h $DB_HOST -U ckan $CKAN_DB -c 'select apikey from public.user where name=\"$CKAN_SYSADMIN_NAME\";"
-    
-    run psql -h $DB_HOST -U ckan $CKAN_DB -c "select apikey from public.user where name='$CKAN_SYSADMIN_NAME';"
-    echo "Check API KEY: $sql_command" >&3
-    echo " - $output" >&3
+    run db -c "select apikey from public.user where name='$CKAN_SYSADMIN_NAME';"
 
-    local api_key=$(echo ${lines[2]} | xargs)
+    if [ "$status" = 0 ]; then
+      api_key="$output"
+    fi
 
     echo "# API KEY $api_key" >&3
     len_api_key=${#api_key} 
@@ -104,32 +111,6 @@ function test_url () {
   local url="http://$HOST:$PORT/$1"
   run curl --silent --fail $url
   [ "$status" -ne 22 ]
-}
-
-function test_create_dataset () {
-  export PGPASSWORD=$CKAN_DB_PW
-  
-  run psql -h db -U ckan $CKAN_DB -c "select apikey from public.user where name='$CKAN_SYSADMIN_NAME';"
-  local api_key=$(echo ${lines[2]} | xargs)  # run fill $output with all response and $line with each response line
-  echo "Create dataset API KEY = $api_key" >&3
-  
-  local json_data=$( sed s/\$RNDCODE/$RNDCODE/g /tests/test-data/test-package-create-01.json )
-  
-  run curl -X POST \
-    http://$HOST:$PORT/api/3/action/package_create \
-    -H "Authorization: $api_key" \
-    -H 'cache-control: no-cache' \
-    -H 'content-type: application/json' \
-    -d "$json_data"
-
-  local success=$(echo $output | grep -o '"success": true')
-
-  if [ "$success" = '"success": true' ]; then
-    return 0;
-  else
-    echo "Failed to create dataset. API KEY $api_key. RND: $RNDCODE OUTPUT: $output" >&3
-    return 1;
-  fi
 }
 
 function test_read_dataset () {

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,3 +1,22 @@
+load /bats/lib/bats-support/load.bash
+load /bats/lib/bats-assert/load.bash
+
+
+# log <msg>...
+#
+# stdin: msg
+#
+# Outputs message to stderr so that will be displayed by bats only when the
+# test fails.
+function log () {
+  if (( $# > 0)); then
+    # Print the arguments
+    echo "$@" >&2
+  else
+    # Print stdin
+    cat >&2
+  fi
+}
 
 function wait_for_app () {
   # The app takes quite a while to startup (solr initialization and


### PR DESCRIPTION
This adds a few BATS libraries to make testing a little less rough.

- Use the git version of BATS (our container is 2 years old)
- [bats-support](https://github.com/bats-core/bats-support) and [bats-assert](https://github.com/bats-core/bats-assert) provide `assert_*` methods
- Use the "pretty" formatter for BATS (`-p`)
- `db` wrapper around psql