### PR TITLE
Add missing plugin and move to postgis

### DIFF
--- a/.env
+++ b/.env
@@ -40,7 +40,7 @@ CKAN_SMTP_PASSWORD=pass
 CKAN_SMTP_MAIL_FROM=ckan@localhost
 
 # Extensions
-CKAN__PLUGINS=envvars image_view text_view recline_view datastore datapusher harvest ckan_harvester geodatagov datajson datajson_harvest geodatagov_miscs z3950_harvester arcgis_harvester geodatagov_geoportal_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester spatial_query datagovtheme
+CKAN__PLUGINS=envvars image_view text_view recline_view datastore datapusher harvest ckan_harvester geodatagov datajson datajson_harvest geodatagov_miscs z3950_harvester arcgis_harvester geodatagov_geoportal_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester spatial_metadata spatial_query datagovtheme
 
 # Harvest settings
 CKAN__HARVEST__MQ__TYPE=redis
@@ -52,3 +52,5 @@ CKAN__HARVEST__LOG_SCOPE=0
 
 CKANEXT__GEODATAGOV__BUREAU_CSV__URL=https://project-open-data.cio.gov/data/omb_bureau_codes.csv
 CKANEXT__GEODATAGOV__BUREAU_CSV__URL_DEFAULT=https://project-open-data.cio.gov/data/omb_bureau_codes.csv
+
+CKAN__SPATIAL__SRID=4326

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.6-alpine
+FROM mdillon/postgis:9.6-alpine
 MAINTAINER Open Knowledge International
 
 # Allow connections; we don't map out any ports so only linked docker containers can connect


### PR DESCRIPTION
Fixes #43 

 - Move from PostgreSQL to Postgis container
 - Add missing Spatial plugin

Now we can see spatial datasets

![image](https://user-images.githubusercontent.com/3237309/83174499-dd15a580-a0f0-11ea-8476-c75394913d86.png)
