### PR TITLE
Hotfix to run tests whitout a text file

### DIFF
--- a/tools/harvest_source_import/check_harvest_sources.py
+++ b/tools/harvest_source_import/check_harvest_sources.py
@@ -62,7 +62,7 @@ for name in names:
         print(f'SKIP already checked source {args.source_type} {name}')
         continue
 
-    row = {'name': name,'time': time.time(), 'source_type': args.source_type}
+    row = {'name': name,'time': time.time()}
 
     # check if already exists locally
     hs = local_ckan.get_full_harvest_source(hs={'name': name})
@@ -142,6 +142,7 @@ for name in names:
     row['status'] = 'Script OK'
     row['url'] = full_hs['url']
     row['config'] = full_hs['config']
+    row['source_type'] = full_hs['source_type']
     row['last_job_status'] = last_job_status
     row['added'] = added
     row['updated'] = updated

--- a/tools/harvest_source_import/check_harvest_sources.py
+++ b/tools/harvest_source_import/check_harvest_sources.py
@@ -40,7 +40,7 @@ if os.path.isfile(args.names_to_test):
     names = f.read().splitlines()
     f.close()
 else:
-    names = args.names_to_tests.split(',')
+    names = args.names_to_test.split(',')
 
 report_file_name = f'report-checks.csv'
 fieldnames = ['name', 'url', 'config', 'source_type', 'status', 'last_job_status',


### PR DESCRIPTION
 - a typo in the script
 - now we are able to run multiple source type tests so we fix the source_type filed at the report