### PR TITLE
GSA harvest fork for notifications

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -18,7 +18,7 @@ chardet==3.0.4
 -e git+https://github.com/GSA/ckanext-datajson.git@4ff469736509fe6bfe6a02dbd230ba4ea8b11660#egg=ckanext-datajson
 ckanext-envvars==0.0.1
 -e git+https://github.com/GSA/ckanext-geodatagov.git@d82eb45067f9b8335b6d767499f218431fb6c215#egg=ckanext-geodatagov
--e git+https://github.com/ckan/ckanext-harvest.git@944f67c48d274df79a2719b5553698e3e6980a51#egg=ckanext-harvest
+-e git+https://github.com/GSA/ckanext-harvest.git@ea6fc07e930b2eb659933bce8cbd850f72db8140#egg=ckanext-harvest
 -e git+https://github.com/davidread/ckanext-report.git@b67875b2a5b4c9b9ab2cf255f074226255ca9398#egg=ckanext-report
 -e git+https://github.com/ckan/ckanext-spatial.git@4ac25f19aa4eb9c798451f5eeb3084f907ccc003#egg=ckanext-spatial
 ckantoolkit==0.0.3

--- a/requirements/poetry.lock
+++ b/requirements/poetry.lock
@@ -244,9 +244,9 @@ python-versions = "*"
 version = "1.3.0"
 
 [package.source]
-reference = "944f67c48d274df79a2719b5553698e3e6980a51"
+reference = "ea6fc07e930b2eb659933bce8cbd850f72db8140"
 type = "git"
-url = "https://github.com/ckan/ckanext-harvest.git"
+url = "https://github.com/GSA/ckanext-harvest.git"
 [[package]]
 category = "main"
 description = "Framework for defining reports in CKAN"
@@ -1155,7 +1155,7 @@ test = ["zope.event"]
 testing = ["zope.event", "nose", "coverage"]
 
 [metadata]
-content-hash = "88c255376ad4ab258aa849e5f2cd5ec29b242d0ffbeae257a666ca71e34c08b3"
+content-hash = "2b755c4dc6cc5a13c9249e2fdb1e87f7b8ef2e88b24694ce95af6cd5c5edb3e4"
 python-versions = "^2.7"
 
 [metadata.files]

--- a/requirements/pyproject.toml
+++ b/requirements/pyproject.toml
@@ -14,7 +14,8 @@ ckanext-datagovtheme = {git = "https://github.com/GSA/ckanext-datagovtheme.git"}
 ckanext-datajson = {git = "https://github.com/GSA/ckanext-datajson.git" }
 ckanext-envvars = "*"
 ckanext-geodatagov = {git = "https://github.com/GSA/ckanext-geodatagov.git" }
-ckanext-harvest = {git = "https://github.com/ckan/ckanext-harvest.git" }
+# ckanext-harvest = {git = "https://github.com/ckan/ckanext-harvest.git" }
+ckanext-harvest = {git = "https://github.com/GSA/ckanext-harvest.git", branch = "datagov-catalog" }
 ckanext-report = {git = "https://github.com/davidread/ckanext-report.git" }
 ckanext-spatial = {git = "https://github.com/ckan/ckanext-spatial.git" }
 ckanext-datagovcatalog = {git = "https://github.com/GSA/ckanext-datagovcatalog.git"}


### PR DESCRIPTION
Related to [GSA#315](https://github.com/GSA/datagov-ckan-multi/issues/315)

Just update dependencies to use [the new GSA harvest fork](https://github.com/GSA/ckanext-harvest/tree/datagov-catalog) which include new notification feature working.