### PR TITLE
Update Ansible group for Jenkins deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
       steps {
         ansiColor('xterm') {
           echo 'Deploying with Ansible'
-          sh 'docker run --rm -v $SSH_KEY_FILE:$SSH_KEY_FILE -v $ANSIBLE_VAULT_FILE:$ANSIBLE_VAULT_FILE -u $(id -u) datagov/datagov-deploy:latest pipenv run ansible-playbook --key-file=$SSH_KEY_FILE --vault-password-file=$ANSIBLE_VAULT_FILE --inventory $INVENTORY $PLAYBOOK --limit v2'
+          sh 'docker run --rm -v $SSH_KEY_FILE:$SSH_KEY_FILE -v $ANSIBLE_VAULT_FILE:$ANSIBLE_VAULT_FILE -u $(id -u) datagov/datagov-deploy:latest pipenv run ansible-playbook --key-file=$SSH_KEY_FILE --vault-password-file=$ANSIBLE_VAULT_FILE --inventory $INVENTORY $PLAYBOOK --limit catalog-next'
         }
       }
     }


### PR DESCRIPTION
v2 was sort of a placeholder/hack. Now we have an explicit catalog-next group
that should be used instead.