### PR TITLE
Boolean config values are dropped by CKAN

### DIFF
--- a/tools/harvest_source_import/remote_ckan/lib.py
+++ b/tools/harvest_source_import/remote_ckan/lib.py
@@ -395,6 +395,10 @@ class RemoteCKAN:
                 config.update(value)
                 extras.remove(extra)
 
+        # CKAN drop config values as boolean, move to string
+        for k, v in config.items():
+            if type(v) is bool:
+                config[k] = str(v)
         return json.dumps(config)
 
     def request_ckan(self, method, url, data):


### PR DESCRIPTION
Related to [Multi#398](https://github.com/GSA/datagov-ckan-multi/issues/398) and [Multi#392](https://github.com/GSA/datagov-ckan-multi/issues/392)

This PR change boolean config values to string

Fix 392
![Screenshot-20200819175340-1033x619](https://user-images.githubusercontent.com/3237309/90688912-8e862c00-e245-11ea-86a7-79673919ff27.png)
