### PR TITLE
Fix GMI based spatial datasets

### DIFF
--- a/.env
+++ b/.env
@@ -56,6 +56,7 @@ CKANEXT__GEODATAGOV__BUREAU_CSV__URL=https://resources.data.gov/schemas/dcat-us/
 CKANEXT__GEODATAGOV__BUREAU_CSV__URL_DEFAULT=https://resources.data.gov/schemas/dcat-us/v1.1/omb_bureau_codes.csv
 
 CKAN__SPATIAL__SRID=4326
+CKAN__SPATIAL__VALIDATOR__PROFILES=iso19139ngdc
 
 # Hide non-existent functions at theme (https://github.com/GSA/catalog.data.gov/issues/50) 
 CKANEXT__DATAGOVTHEME__USE__ARCHIVER=false

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -17,7 +17,7 @@ chardet==3.0.4
 -e git+https://github.com/GSA/ckanext-datagovtheme.git@c3536bec916312d93bab88f56c45d422db7660b9#egg=ckanext-datagovtheme
 -e git+https://github.com/GSA/ckanext-datajson.git@214ec53c9071d18bc7f7a241a28f6d7f0038276e#egg=ckanext-datajson
 ckanext-envvars==0.0.1
--e git+https://github.com/GSA/ckanext-geodatagov.git@1ab84ced52b69dcfccdb8060b10ca5ae87766c79#egg=ckanext-geodatagov
+-e git+https://github.com/GSA/ckanext-geodatagov.git@263aa0f6e2ba9a9540ada8b20e934abfb4d498fd#egg=ckanext-geodatagov
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@54647da628609543e01731bfc37f0c3d0ad9f0e2#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/ckanext-harvest.git@ea6fc07e930b2eb659933bce8cbd850f72db8140#egg=ckanext-harvest
 -e git+https://github.com/davidread/ckanext-report.git@b67875b2a5b4c9b9ab2cf255f074226255ca9398#egg=ckanext-report

--- a/requirements/poetry.lock
+++ b/requirements/poetry.lock
@@ -233,7 +233,7 @@ python-versions = "*"
 version = "0.1"
 
 [package.source]
-reference = "1ab84ced52b69dcfccdb8060b10ca5ae87766c79"
+reference = "263aa0f6e2ba9a9540ada8b20e934abfb4d498fd"
 type = "git"
 url = "https://github.com/GSA/ckanext-geodatagov.git"
 [[package]]
@@ -1614,6 +1614,7 @@ rq = [
     {file = "rq-0.6.0.tar.gz", hash = "sha256:d6502f5041953b2e5f5411a59bfc9661f7fb2af2a7f412f0f7bc62b2e56d9341"},
 ]
 shapely = [
+    {file = "Shapely-1.7.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4c10f317e379cc404f8fc510cd9982d5d3e7ba13a9cfd39aa251d894c6366798"},
     {file = "Shapely-1.7.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:17df66e87d0fe0193910aeaa938c99f0b04f67b430edb8adae01e7be557b141b"},
     {file = "Shapely-1.7.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:da38ed3d65b8091447dc3717e5218cc336d20303b77b0634b261bc5c1aa2bae8"},
     {file = "Shapely-1.7.1-cp35-cp35m-win32.whl", hash = "sha256:8e7659dd994792a0aad8fb80439f59055a21163e236faf2f9823beb63a380e19"},


### PR DESCRIPTION
Related to [Multi#386](https://github.com/GSA/datagov-ckan-multi/issues/386)

This PR:
 - Change the default profile to validate XML from WAF harvest sources
 - Update dependencies (and get a new version of GeoDataGov extension)
 