### PR TITLE
Run integrations test for our extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - run: make build ci
       - run: make test
       - run: make lint-all
+      - run: make test-extensions
 
   deploy-sandbox:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,24 @@ harvest-gather-queue:
 
 harvest-check-finished-jobs:
 	docker-compose exec ckan paster --plugin=ckanext-harvest harvester run
+
+test-extensions:
+	# test our extensions
+
+	# deal with the CKAN path
+	docker-compose exec ckan bash -c "ln -sf $(CKAN_HOME)/src/ckan $(CKAN_HOME)/ckan"
+	
+	# full test geodatagov
+	docker-compose exec ckan bash -c \
+		"cd $(CKAN_HOME)/src/ckanext-geodatagov && \
+		 nosetests --ckan --with-pylons=test.ini ckanext/geodatagov/tests --nologcapture"
+	
+	# full test datajson
+	docker-compose exec ckan bash -c \
+		"cd $(CKAN_HOME)/src/ckanext-datajson && \
+		 nosetests --ckan --with-pylons=test.ini ckanext/datajson/tests --nologcapture"
+	
+	# full test datagovtheme
+	docker-compose exec ckan bash -c \
+		"cd $(CKAN_HOME)/src/ckanext-datagovtheme && \
+		 nosetests --ckan --with-pylons=test.ini ckanext/datagovtheme/tests --nologcapture"


### PR DESCRIPTION
Each extension has its own test.
In the current environment if a change in _extension A_ breaks something in _extension B_ we didn't capture.
We need an environment that test changes in one extension that affect others.
