### PR TITLE
Add new relic python requirement

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -51,6 +51,7 @@ mako==1.1.3
 markdown==3.1.1
 markupsafe==1.1.1
 messytables==0.15.2
+newrelic==5.20.1.150
 nose==1.3.7
 ofs==0.4.2
 owslib==0.8.6

--- a/requirements/poetry.lock
+++ b/requirements/poetry.lock
@@ -646,6 +646,17 @@ pdf = ["pdftables (>=0.0.4)"]
 
 [[package]]
 category = "main"
+description = "New Relic Python Agent"
+name = "newrelic"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+version = "5.20.1.150"
+
+[package.extras]
+infinite-tracing = ["grpcio (<2)", "protobuf (<4)"]
+
+[[package]]
+category = "main"
 description = "nose extends unittest to make testing easier"
 name = "nose"
 optional = false
@@ -1239,7 +1250,7 @@ test = ["zope.event"]
 testing = ["zope.event", "nose", "coverage"]
 
 [metadata]
-content-hash = "4a1a0a7c4897a5c81d1e925871caf7dde7ba8a087d35d75c49205d4c90649b25"
+content-hash = "94bfaadb90ccb07ed7d10620eddac020fbf8751fbea912192f92ede50e53713a"
 lock-version = "1.0"
 python-versions = "^2.7"
 
@@ -1523,6 +1534,21 @@ markupsafe = [
 ]
 messytables = [
     {file = "messytables-0.15.2.tar.gz", hash = "sha256:227a5aac364919a7d3faa6ce04027fcbd03e041efcd3d57fabb1d1067591a2cd"},
+]
+newrelic = [
+    {file = "newrelic-5.20.1.150-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:ba03e55ef5ede5b11b702068025bc982869ab6a2b87597635b2ef5e4af37c29a"},
+    {file = "newrelic-5.20.1.150-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:4ac8ca6118124c4c060454c1facbcb9679ac848c5a0aaa58b6ad8a0ade7742b8"},
+    {file = "newrelic-5.20.1.150-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b184a293e94f0eb87f344d3ef80eedbc35c7e25e60a42101513d55c3a29fe08e"},
+    {file = "newrelic-5.20.1.150-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:eb465af68f572a3a1e502022d8ac111439be90dffa768317a347491f52fe0523"},
+    {file = "newrelic-5.20.1.150-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:9b9df45dc3badeec31a1d8adc4153a601b2fe25ee9d3a98a502c6fa8239d2b71"},
+    {file = "newrelic-5.20.1.150-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:643723e1bc82b106b232968820437f0db113d1efbe140e7adcd4425a2c735aa8"},
+    {file = "newrelic-5.20.1.150-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f10a7ca15d87dfc516daf69e379ae979e07699dd723dda319f1ae462552a3bc3"},
+    {file = "newrelic-5.20.1.150-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5fc4e6234d4eb06b9c6f0b052260b2d65537c25f393afae3cfe55848935d3fa9"},
+    {file = "newrelic-5.20.1.150-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0eaab77f295f6efa16887ef8594ec8601b1f1071fef8fc78818d71334e5545d4"},
+    {file = "newrelic-5.20.1.150-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:a4503269d1cf204e652c41607bf1cbd73f0b37b4e1de237096f895ab37502bb4"},
+    {file = "newrelic-5.20.1.150-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b3441f0328645e9c2664341bed34ac4d5cadd58b88111b0680e2128d0f2be170"},
+    {file = "newrelic-5.20.1.150-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c21f8fff642760aa8f9d58816f5c801d5809da48ecafccf92735485f3ed3fbcb"},
+    {file = "newrelic-5.20.1.150.tar.gz", hash = "sha256:99847f587383d81c700d67b6eefdbc66d85512306276c62111af5af19d47f90f"},
 ]
 nose = [
     {file = "nose-1.3.7-py2-none-any.whl", hash = "sha256:dadcddc0aefbf99eea214e0f1232b94f2fa9bd98fa8353711dacb112bfcbbb2a"},

--- a/requirements/pyproject.toml
+++ b/requirements/pyproject.toml
@@ -122,6 +122,8 @@ werkzeug = "~0.15.3"
 
 gunicorn = "*"
 
+# New Relic
+newrelic = "*"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Related to https://github.com/GSA/datagov-deploy/issues/2263, adding new relic installation at the application level