### PR TITLE
Build image just one time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,27 @@
 version: 2.1
+
 jobs:
-  bat_test:
-    machine: 
-      docker_layer_caching: true 
+  test:
+    machine: true
     steps:
       - checkout
-      - run: make test
-      
-  build:
-    machine: 
-      docker_layer_caching: true 
-    steps:
-      - checkout
-      - run: make build ci
-      - run: make lint-all
-      - run: make test-extensions
-      
+      - run:
+          name: build
+          command: make build
+      - run:
+          name: Archive Docker image
+          command: docker save -o image.tar datagov/catalog.data.gov:latest
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./image.tar
+      - run: 
+          name: lint and test
+          command: |
+            docker-compose up -d
+            make lint-all
+            make quick-bat-test
+    
   deploy-sandbox:
     docker:
       - image: circleci/python:3.6
@@ -51,10 +57,14 @@ jobs:
     machine: true
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.tar
       - run:
           name: Tag and publish image
           command: |
-            docker build -t datagov/catalog.data.gov:latest ckan/
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker push datagov/catalog.data.gov:latest
 
@@ -64,19 +74,17 @@ workflows:
   commit:
     jobs:
       - start_ckan_28
-      - build
       - deploy-sandbox:
           requires:
-            - build
+            - test
           filters:
             branches:
               only: master
       - test_importer
-      - bat_test
+      - test
       - docker_publish:
           requires:
-            - build
-            - bat_test
+            - test
           filters:
             branches:
               only: master

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ all: build
 
 ci:
 	docker-compose up -d
-	sleep 40
 
 build:
+	docker build -t datagov/catalog.data.gov:latest ckan/
 	docker-compose build
 
 clean:
@@ -18,10 +18,12 @@ copy-src:
 	docker cp catalog-app_ckan_1:$(CKAN_HOME)/src .
 
 dev:
+	docker build -t datagov/catalog.data.gov:latest ckan/
 	docker-compose build
 	docker-compose up
 
 debug:
+	docker build -t datagov/catalog.data.gov:latest ckan/
 	docker-compose build
 	docker-compose run --service-ports ckan
 
@@ -29,13 +31,14 @@ requirements:
 	docker-compose run --rm -T ckan pip --quiet freeze > requirements-freeze.txt
 
 test:
+	docker build -t datagov/catalog.data.gov:latest ckan/
+	docker-compose build
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml build
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit test
 
-quick-test:
+quick-bat-test:
 	# if local environment is already build and running 
-	docker-compose -f docker-compose.yml -f docker-compose.test.yml build test
-	docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit test
+	docker-compose -f docker-compose.yml -f docker-compose.test.yml up test
 
 update-dependencies:
 	docker-compose run --rm -T ckan freeze-requirements.sh $(shell id -u) $(shell id -g)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,7 @@ version: "3"
 
 services:
   ckan:
-    build:
-      context: ckan/
-      dockerfile: Dockerfile
-      args:
-        - TZ=${TZ}
+    image: datagov/catalog.data.gov:latest
     env_file:
       - .env
     depends_on:
@@ -26,7 +22,6 @@ services:
     image: keitaro/ckan-datapusher
 
   db:
-    container_name: db
     env_file:
       - .env
     build:
@@ -35,7 +30,6 @@ services:
       - pg_data:/var/lib/postgresql/data
 
   solr:
-    container_name: solr
     build:
       context: solr/
     ports:
@@ -44,7 +38,6 @@ services:
       - solr_data:/opt/solr/server/solr/ckan/data/index
 
   redis:
-    container_name: redis
     image: redis:alpine
 
 volumes:


### PR DESCRIPTION
CircleCI is running out of memory. 
This PR:
 - Fixes the error 137 (memory error)
 - Build just one time the main docker image and then share it using local caches
 - Remove test extension because now we have the right environment within extensions.
