### PR TITLE
Update dependencies for datagovcatalog extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,3 +119,8 @@ test-extensions:
 	docker-compose exec ckan bash -c \
 		"cd $(CKAN_HOME)/src/ckanext-geodatagov && \
 		 nosetests --ckan --with-pylons=$(CKAN_HOME)/src/ckan/test-catalog-next.ini ckanext/geodatagov/tests --debug=ckanext"
+
+	# full test geodatagov
+	docker-compose exec ckan bash -c \
+		"cd $(CKAN_HOME)/src/ckanext-datagovdatalog && \
+		 nosetests --ckan --with-pylons=$(CKAN_HOME)/src/ckan/test-catalog-next.ini ckanext/datagovdatalog/tests --debug=ckanext"

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -13,9 +13,9 @@ cffi==1.12.3
 chardet==3.0.4
 -e git+https://github.com/ckan/ckan.git@eca78d5df65414249c5a76620c1acae1ddc76cc3#egg=ckan
 -e git+https://github.com/ckan/ckanext-archiver.git@4cb10ac9f96fc78bc7be4b3dee8fbc56049b2865#egg=ckanext-archiver
--e git+https://github.com/GSA/ckanext-datagovcatalog.git@b7456823f2f642067c751ec05eed5fd63339ace8#egg=ckanext-datagovcatalog
+-e git+https://github.com/GSA/ckanext-datagovcatalog.git@73c6949559bab1ef571656b1c30220eef20685d8#egg=ckanext-datagovcatalog
 -e git+https://github.com/GSA/ckanext-datagovtheme.git@490a8968941467ca6a493a9191d389f33e70e488#egg=ckanext-datagovtheme
--e git+https://github.com/GSA/ckanext-datajson.git@cc360697a17530f0a1d8c126c28402845961f203#egg=ckanext-datajson
+-e git+https://github.com/GSA/ckanext-datajson.git@a66f314333862bc316086a25e735f472cb5b29fe#egg=ckanext-datajson
 -e git+https://github.com/ckan/ckanext-dcat@6b7ec505f303fb18e0eebcebf67130d36b3dca82#egg=ckanext-dcat
 ckanext-envvars==0.0.1
 -e git+https://github.com/GSA/ckanext-geodatagov.git@73fd9299092d7b33342bfc746c1def38389753f7#egg=ckanext-geodatagov

--- a/ckan/test-catalog-next.ini
+++ b/ckan/test-catalog-next.ini
@@ -12,7 +12,8 @@ ckan.site_title = My Test CKAN Site
 ckan.site_description = A test site for testing my CKAN extension
 ckan.plugins = envvars image_view text_view recline_view datastore datapusher datagov_harvest ckan_harvester geodatagov datajson datajson_harvest geodatagov_miscs z3950_harvester arcgis_harvester geodatagov_geoportal_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester spatial_metadata spatial_query report qa archiver datagovtheme datagovcatalog googleanalyticsbasic dcat dcat_json_interface structured_data
 ckan.harvest.mq.type = redis
-
+ckan.tracking_enabled = true
+googleanalytics.ids = UA-1010101-1
 # custom config for test extensions
 ckanext.geodatagov.dynamic_menu.url_default = https://www.data.gov/app/plugins/datagov-custom/wp_download_links.php
 

--- a/requirements/poetry.lock
+++ b/requirements/poetry.lock
@@ -192,7 +192,7 @@ python-versions = "*"
 version = "0.0.1"
 
 [package.source]
-reference = "b7456823f2f642067c751ec05eed5fd63339ace8"
+reference = "73c6949559bab1ef571656b1c30220eef20685d8"
 type = "git"
 url = "https://github.com/GSA/ckanext-datagovcatalog.git"
 [[package]]
@@ -216,7 +216,7 @@ python-versions = "*"
 version = "0.1"
 
 [package.source]
-reference = "cc360697a17530f0a1d8c126c28402845961f203"
+reference = "a66f314333862bc316086a25e735f472cb5b29fe"
 type = "git"
 url = "https://github.com/GSA/ckanext-datajson.git"
 [[package]]


### PR DESCRIPTION
This PR:
 - Include [latest changes for DataGovCatalog](https://github.com/GSA/ckanext-datagovcatalog/pull/19)
 - Add test for DataGovCatalog extension inside catalog-next makefile