### PR TITLE
Script to add locations table

### DIFF
--- a/tools/locations-table/README.md
+++ b/tools/locations-table/README.md
@@ -1,0 +1,10 @@
+# Locations table
+
+The locations table [was defined in 2016](https://github.com/GSA/datagov-deploy/search?q=location+table&type=commits).  
+This table was deleted from the repo but is still available from old commits: [locations.sql.gz](https://github.com/GSA/datagov-deploy/raw/71936f004be1882a506362670b82c710c64ef796/ansible/roles/software/ec2/ansible/files/locations.sql.gz).  
+
+This table could be dd to database with
+
+```
+./install-locations-table.sh HOST DB_NAME DB_USER PASS"
+```

--- a/tools/locations-table/install-locations-table.sh
+++ b/tools/locations-table/install-locations-table.sh
@@ -1,0 +1,16 @@
+echo "*** USAGE: $(basename "$0") HOST DB_NAME DB_USER PASS"
+
+DEST_FOLDER=/tmp
+HOST=$1
+DB_NAME=$2
+DB_USER=$3
+PASS=$4
+
+echo "Downloading locations table"
+wget https://github.com/GSA/datagov-deploy/raw/71936f004be1882a506362670b82c710c64ef796/ansible/roles/software/ec2/ansible/files/locations.sql.gz -O $DEST_FOLDER/locations.sql.gz
+
+echo "Creating locations table"
+gunzip -c ${DEST_FOLDER}/locations.sql.gz | PGPASSWORD=${PASS} psql -h $HOST -U $DB_USER -d $DB_NAME -v ON_ERROR_STOP=1
+
+echo "Cleaning"
+rm -f $DEST_FOLDER/locations.sql.gz


### PR DESCRIPTION
Related to [Deploy#2338](https://github.com/GSA/datagov-deploy/issues/2338)

This PR adds a script to recover the locations table.

The script was tested in sandbox-next and it's working

![image](https://user-images.githubusercontent.com/3237309/98683738-29257100-2344-11eb-9c9a-204a72704049.png)
