### PR TITLE
Update saml2 and other extensions

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -14,16 +14,16 @@ chardet==3.0.4
 -e git+https://github.com/ckan/ckan.git@eca78d5df65414249c5a76620c1acae1ddc76cc3#egg=ckan
 -e git+https://github.com/ckan/ckanext-archiver.git@4cb10ac9f96fc78bc7be4b3dee8fbc56049b2865#egg=ckanext-archiver
 -e git+https://github.com/GSA/ckanext-datagovcatalog.git@531d20c925b4b8954e71a25f992ebbf9000b4c30#egg=ckanext-datagovcatalog
--e git+https://github.com/GSA/ckanext-datagovtheme.git@a268f37444be59dcbfd4a8d8068d29c8a1fc329a#egg=ckanext-datagovtheme
+-e git+https://github.com/GSA/ckanext-datagovtheme.git@86fa62619139a4c0d494b6a9f4edd7b8eff35a37#egg=ckanext-datagovtheme
 -e git+https://github.com/GSA/ckanext-datajson.git@563b49f50be86f77bff2ee9859c6004bcc94b7f7#egg=ckanext-datajson
 -e git+https://github.com/ckan/ckanext-dcat@6b7ec505f303fb18e0eebcebf67130d36b3dca82#egg=ckanext-dcat
 ckanext-envvars==0.0.1
 -e git+https://github.com/GSA/ckanext-geodatagov.git@5393def8735fd151f9f9a70fa72bd795d9375342#egg=ckanext-geodatagov
--e git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@54647da628609543e01731bfc37f0c3d0ad9f0e2#egg=ckanext-googleanalyticsbasic
--e git+https://github.com/ckan/ckanext-harvest.git@d3432e9c845938f4c8fcbd25073f91afbd3451b8#egg=ckanext-harvest
+-e git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@b84b93098e80b61c1073236958c33b096987ac3a#egg=ckanext-googleanalyticsbasic
+-e git+https://github.com/ckan/ckanext-harvest.git@d00553831e20ae7c6737206ddb8a613b494f2b86#egg=ckanext-harvest
 -e git+https://github.com/ckan/ckanext-qa.git@d7d384cb18a85243ea62ef0bcc76bc1775f1c806#egg=ckanext-qa
 -e git+https://github.com/davidread/ckanext-report.git@b67875b2a5b4c9b9ab2cf255f074226255ca9398#egg=ckanext-report
--e git+https://github.com/GSA/ckanext-saml2.git@07df14dba0d42c83cd6cdd95a16279198a8d5349#egg=ckanext-saml2
+-e git+https://github.com/GSA/ckanext-saml2.git@3a1145ba5c71433cff488707d47d41ae2941e040#egg=ckanext-saml2
 -e git+https://github.com/ckan/ckanext-spatial.git@4ac25f19aa4eb9c798451f5eeb3084f907ccc003#egg=ckanext-spatial
 ckantoolkit==0.0.3
 click==6.7
@@ -65,7 +65,7 @@ newrelic==5.22.1.152
 nose==1.3.7
 ofs==0.4.2
 owslib==0.8.6
-packaging==20.7
+packaging==20.8
 pairtree==0.7.1-T
 passlib==1.7.3
 paste==1.7.5.1
@@ -82,7 +82,7 @@ pygments==2.5.2
 pylons==0.9.7
 pyopenssl==18.0.0
 pyparsing==2.4.7
--e git+https://github.com/GSA/pysaml2.git@08883cda0a8c0743b8a9cfa6ec176ddf9b9e7a56#egg=pysaml2
+-e git+https://github.com/GSA/pysaml2.git@45d0ea01b3e3c1fba2757387f8068d57153ce2ce#egg=pysaml2
 pysolr==3.6.0
 python-dateutil==1.5
 python-magic==0.4.15
@@ -118,6 +118,6 @@ webhelpers==1.3
 webob==1.0.8
 webtest==1.4.3
 werkzeug==0.15.6
-xlrd==1.2.0
+xlrd==2.0.1
 zope.interface==4.3.2
 -e git+https://github.com/asl2/PyZ3950.git@c2282c73182cef2beca0f65b1eb7699c9b24512e#egg=PyZ3950

--- a/requirements/poetry.lock
+++ b/requirements/poetry.lock
@@ -204,7 +204,7 @@ python-versions = "*"
 version = "0.1"
 
 [package.source]
-reference = "a268f37444be59dcbfd4a8d8068d29c8a1fc329a"
+reference = "86fa62619139a4c0d494b6a9f4edd7b8eff35a37"
 type = "git"
 url = "https://github.com/GSA/ckanext-datagovtheme.git"
 [[package]]
@@ -260,7 +260,7 @@ python-versions = "*"
 version = "0.1"
 
 [package.source]
-reference = "54647da628609543e01731bfc37f0c3d0ad9f0e2"
+reference = "b84b93098e80b61c1073236958c33b096987ac3a"
 type = "git"
 url = "https://github.com/GSA/ckanext-googleanalyticsbasic.git"
 [[package]]
@@ -272,7 +272,7 @@ python-versions = "*"
 version = "1.3.2"
 
 [package.source]
-reference = "d3432e9c845938f4c8fcbd25073f91afbd3451b8"
+reference = "d00553831e20ae7c6737206ddb8a613b494f2b86"
 type = "git"
 url = "https://github.com/ckan/ckanext-harvest.git"
 [[package]]
@@ -322,7 +322,7 @@ version = "0.4.0"
 python-memcached = "1.48"
 
 [package.source]
-reference = "07df14dba0d42c83cd6cdd95a16279198a8d5349"
+reference = "3a1145ba5c71433cff488707d47d41ae2941e040"
 type = "git"
 url = "https://github.com/GSA/ckanext-saml2.git"
 [[package]]
@@ -801,7 +801,7 @@ description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.7"
+version = "20.8"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
@@ -1021,7 +1021,7 @@ six = "*"
 s2repoze = ["paste", "zope.interface", "repoze.who"]
 
 [package.source]
-reference = "08883cda0a8c0743b8a9cfa6ec176ddf9b9e7a56"
+reference = "45d0ea01b3e3c1fba2757387f8068d57153ce2ce"
 type = "git"
 url = "https://github.com/GSA/pysaml2.git"
 [[package]]
@@ -1416,11 +1416,16 @@ watchdog = ["watchdog"]
 
 [[package]]
 category = "main"
-description = "Library for developers to extract data from Microsoft Excel (tm) spreadsheet files"
+description = "Library for developers to extract data from Microsoft Excel (tm) .xls spreadsheet files"
 name = "xlrd"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.2.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+version = "2.0.1"
+
+[package.extras]
+build = ["wheel", "twine"]
+docs = ["sphinx"]
+test = ["pytest", "pytest-cov"]
 
 [[package]]
 category = "main"
@@ -1836,8 +1841,8 @@ owslib = [
     {file = "OWSLib-0.8.6.tar.gz", hash = "sha256:8646672fe2ec91cad8e0f80199d001d485c0ae7c32c5cbd5cba6c019a6d84ac6"},
 ]
 packaging = [
-    {file = "packaging-20.7-py2.py3-none-any.whl", hash = "sha256:eb41423378682dadb7166144a4926e443093863024de508ca5c9737d6bc08376"},
-    {file = "packaging-20.7.tar.gz", hash = "sha256:05af3bb85d320377db281cf254ab050e1a7ebcbf5410685a9a407e18a1f81236"},
+    {file = "packaging-20.8-py2.py3-none-any.whl", hash = "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858"},
+    {file = "packaging-20.8.tar.gz", hash = "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"},
 ]
 pairtree = [
     {file = "Pairtree-0.7.1-T.tar.gz", hash = "sha256:24f3778addb09b68fc82dcc905ecee2b9783b324995cfd31dd0cf68226b4f5c8"},
@@ -2016,6 +2021,7 @@ rq = [
     {file = "rq-0.6.0.tar.gz", hash = "sha256:d6502f5041953b2e5f5411a59bfc9661f7fb2af2a7f412f0f7bc62b2e56d9341"},
 ]
 shapely = [
+    {file = "Shapely-1.7.1-1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:46da0ea527da9cf9503e66c18bab6981c5556859e518fe71578b47126e54ca93"},
     {file = "Shapely-1.7.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4c10f317e379cc404f8fc510cd9982d5d3e7ba13a9cfd39aa251d894c6366798"},
     {file = "Shapely-1.7.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:17df66e87d0fe0193910aeaa938c99f0b04f67b430edb8adae01e7be557b141b"},
     {file = "Shapely-1.7.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:da38ed3d65b8091447dc3717e5218cc336d20303b77b0634b261bc5c1aa2bae8"},
@@ -2033,6 +2039,7 @@ shapely = [
     {file = "Shapely-1.7.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:90a3e2ae0d6d7d50ff2370ba168fbd416a53e7d8448410758c5d6a5920646c1d"},
     {file = "Shapely-1.7.1-cp38-cp38-win32.whl", hash = "sha256:a3774516c8a83abfd1ddffb8b6ec1b0935d7fe6ea0ff5c31a18bfdae567b4eba"},
     {file = "Shapely-1.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:6593026cd3f5daaea12bcc51ae5c979318070fefee210e7990cb8ac2364e79a1"},
+    {file = "Shapely-1.7.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b40cc7bb089ae4aa9ddba1db900b4cd1bce3925d2a4b5837b639e49de054784f"},
     {file = "Shapely-1.7.1-cp39-cp39-win32.whl", hash = "sha256:2df5260d0f2983309776cb41bfa85c464ec07018d88c0ecfca23d40bfadae2f1"},
     {file = "Shapely-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:a5c3a50d823c192f32615a2a6920e8c046b09e07a58eba220407335a9cd2e8ea"},
     {file = "Shapely-1.7.1.tar.gz", hash = "sha256:1641724c1055459a7e2b8bbe47ba25bdc89554582e62aec23cb3f3ca25f9b129"},
@@ -2118,8 +2125,8 @@ werkzeug = [
     {file = "Werkzeug-0.15.6.tar.gz", hash = "sha256:0a24d43be6a7dce81bae05292356176d6c46d63e42a0dd3f9504b210a9cfaa43"},
 ]
 xlrd = [
-    {file = "xlrd-1.2.0-py2.py3-none-any.whl", hash = "sha256:e551fb498759fa3a5384a94ccd4c3c02eb7c00ea424426e212ac0c57be9dfbde"},
-    {file = "xlrd-1.2.0.tar.gz", hash = "sha256:546eb36cee8db40c3eaa46c351e67ffee6eeb5fa2650b71bc4c758a29a1b29b2"},
+    {file = "xlrd-2.0.1-py2.py3-none-any.whl", hash = "sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd"},
+    {file = "xlrd-2.0.1.tar.gz", hash = "sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88"},
 ]
 "zope.interface" = [
     {file = "zope.interface-4.3.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:10aba8ab3e011b797656d3a6d0ff8709ee471024f32d6fd056326cca4123e95f"},


### PR DESCRIPTION
This PR update dependencies to run saml2 in the sandbox.
Related to [Multi#532](https://github.com/GSA/datagov-ckan-multi/issues/532)
