### PR TITLE
Fix harvest_source_import test on GH actions

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -40,6 +40,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          architecture: x64
       - name: test_importer
         run: make test-import-tool
 

--- a/tools/harvest_source_import/dev-requirements.txt
+++ b/tools/harvest_source_import/dev-requirements.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 pytest>=5.4.2
 pytest-vcr>=1.0.2
 flake8>=3.8.1


### PR DESCRIPTION
The harvest source import tool is only built for python 3 and we need to make sure to setup GH actions with python 3.