### PR TITLE
Add db inits for extension and gunicorn server

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -58,7 +58,7 @@ jobs:
           if-no-files-found: error
 
   deploy-development:
-    if: github.ref == 'refs/heads/develop'
+    # if: github.ref == 'refs/heads/develop'
     name: deploy (development)
     environment: development
     runs-on: ubuntu-latest

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -58,7 +58,7 @@ jobs:
           if-no-files-found: error
 
   deploy-development:
-    # if: github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/develop'
     name: deploy (development)
     environment: development
     runs-on: ubuntu-latest

--- a/cfstart.sh
+++ b/cfstart.sh
@@ -54,4 +54,4 @@ paster --plugin=ckanext-qa qa init --config=$CKAN_INI
 
 # Fire it up!
 
-exec ckan/setup/server_start.sh -b 0.0.0.0:$PORT -t 9000
+exec ckan/setup/server_start.sh --bind 0.0.0.0:$PORT --timeout 30

--- a/cfstart.sh
+++ b/cfstart.sh
@@ -42,15 +42,21 @@ export CKAN_REDIS_URL=rediss://:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT
 DATABASE_URL=$CKAN_SQLALCHEMY_URL ./configure-postgis.py
 
 # Edit the config file to use our values
-ckan config-tool ckan/setup/production.ini -s server:main -e port=${PORT}
+export CKAN_INI=ckan/setup/production.ini
+ckan config-tool $CKAN_INI -s server:main -e port=${PORT}
 # ckan config-tool ckan/setup/production.ini \
 #     "ckan.storage_path=/home/vcap/app/files"
 
 # Run migrations
-# paster --plugin=ckan db upgrade -c ckan/setup/production.ini
-ckan db upgrade -c ckan/setup/production.ini 
+# paster --plugin=ckan db upgrade -c $CKAN_INI
+ckan db upgrade -c $CKAN_INI
+paster --plugin=ckanext-harvest harvester initdb --config=$CKAN_INI
+paster --plugin=ckanext-report report initdb --config=$CKAN_INI
+paster --plugin=ckanext-archiver archiver init --config=$CKAN_INI
+paster --plugin=ckanext-qa qa init --config=$CKAN_INI
 
 # Fire it up!
-# exec ckan -c ckan/setup/production.ini run -H 0.0.0.0 -p $PORT
-exec paster --plugin=ckan serve ckan/setup/production.ini
+# exec ckan -c $CKAN_INI run -H 0.0.0.0 -p $PORT
+# exec paster --plugin=ckan serve $CKAN_INI
 
+exec ckan/setup/server_start.sh -b 0.0.0.0:$PORT -t 9000

--- a/cfstart.sh
+++ b/cfstart.sh
@@ -44,11 +44,8 @@ DATABASE_URL=$CKAN_SQLALCHEMY_URL ./configure-postgis.py
 # Edit the config file to use our values
 export CKAN_INI=ckan/setup/production.ini
 ckan config-tool $CKAN_INI -s server:main -e port=${PORT}
-# ckan config-tool ckan/setup/production.ini \
-#     "ckan.storage_path=/home/vcap/app/files"
 
 # Run migrations
-# paster --plugin=ckan db upgrade -c $CKAN_INI
 ckan db upgrade -c $CKAN_INI
 paster --plugin=ckanext-harvest harvester initdb --config=$CKAN_INI
 paster --plugin=ckanext-report report initdb --config=$CKAN_INI
@@ -56,7 +53,5 @@ paster --plugin=ckanext-archiver archiver init --config=$CKAN_INI
 paster --plugin=ckanext-qa qa init --config=$CKAN_INI
 
 # Fire it up!
-# exec ckan -c $CKAN_INI run -H 0.0.0.0 -p $PORT
-# exec paster --plugin=ckan serve $CKAN_INI
 
 exec ckan/setup/server_start.sh -b 0.0.0.0:$PORT -t 9000

--- a/ckan/setup/server_start.sh
+++ b/ckan/setup/server_start.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
 
-DIR="$(dirname "${BASH_SOURCE[0]}")"
-
-if test -f "$DIR/.env"; then
-    set -o allexport; source $DIR/.env; set +o allexport
-fi
-
 # Run web application
 exec newrelic-admin run-program gunicorn --worker-class gevent --paste $CKAN_INI "$@"


### PR DESCRIPTION
Related to https://github.com/GSA/datagov-deploy/issues/2604

The deploy worked, however the smoke test failed because the server was 7 seconds from actually serving traffic. Adding the db initializations causes the startup script to take 17 seconds (was already waiting 10 seconds before running the smoke test)...

Having that much down time isn't great whenever we deploy. Does anyone have a better process for running those db initializations? Should we run them as a thread, similar to how we [run the seeding script for inventory](https://github.com/GSA/inventory-app/blob/main/start.sh#L65)

Blocked by https://github.com/GSA/catalog.data.gov/pull/243; need secret service integration before adding necessary New Relic variables for start script... See [secret parsing](https://github.com/GSA/inventory-app/blob/main/cfstart.sh#L39) and [environment defaults](https://github.com/GSA/inventory-app/blob/main/manifest.yml#L23-L27) on inventory.