### PR TITLE
Build and tag images with fcs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,13 @@ jobs:
           command: make build
       - run:
           name: Archive Catalog Docker image
-          command: docker save -o image-catalog.tar datagov/catalog.data.gov:latest
+          command: docker save -o image-catalog.tar datagov/catalog.data.gov:fcs
       - run:
           name: Archive Solr Docker image
-          command: docker save -o image-solr.tar datagov/catalog.data.gov.solr:latest
+          command: docker save -o image-solr.tar datagov/catalog.data.gov.solr:fcs
       - run:
           name: Archive DB Docker image
-          command: docker save -o image-db.tar datagov/catalog.data.gov.db:latest
+          command: docker save -o image-db.tar datagov/catalog.data.gov.db:fcs
       - persist_to_workspace:
           root: .
           paths:
@@ -75,7 +75,7 @@ jobs:
           name: Tag and publish catalog image
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push datagov/catalog.data.gov:latest
+            docker push datagov/catalog.data.gov:fcs
 
   docker_publish_solr:
     machine: true
@@ -90,7 +90,7 @@ jobs:
           name: Tag and publish SOLR image
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push datagov/catalog.data.gov.solr:latest
+            docker push datagov/catalog.data.gov.solr:fcs
             
 
   docker_publish_db:
@@ -106,7 +106,7 @@ jobs:
           name: Tag and publish DB image
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push datagov/catalog.data.gov.db:latest
+            docker push datagov/catalog.data.gov.db:fcs
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ ci:
 	docker-compose up -d
 
 build:
-	docker build -t datagov/catalog.data.gov:latest ckan/
-	docker build -t datagov/catalog.data.gov.solr:latest solr/
-	docker build -t datagov/catalog.data.gov.db:latest postgresql/
+	docker build -t datagov/catalog.data.gov:fcs ckan/
+	docker build -t datagov/catalog.data.gov.solr:fcs solr/
+	docker build -t datagov/catalog.data.gov.db:fcs postgresql/
 	docker-compose build
 
 clean:
@@ -20,12 +20,12 @@ copy-src:
 	docker cp catalog-app_ckan_1:$(CKAN_HOME)/src .
 
 dev:
-	docker build -t datagov/catalog.data.gov:latest ckan/
+	docker build -t datagov/catalog.data.gov:fcs ckan/
 	docker-compose build
 	docker-compose up
 
 debug:
-	docker build -t datagov/catalog.data.gov:latest ckan/
+	docker build -t datagov/catalog.data.gov:fcs ckan/
 	docker-compose build
 	docker-compose run --service-ports ckan
 
@@ -33,7 +33,7 @@ requirements:
 	docker-compose run --rm -T ckan pip --quiet freeze > requirements-freeze.txt
 
 test:
-	docker build -t datagov/catalog.data.gov:latest ckan/
+	docker build -t datagov/catalog.data.gov:fcs ckan/
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml build
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit test
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   ckan:
-    image: datagov/catalog.data.gov:latest
+    image: datagov/catalog.data.gov:fcs
     env_file:
       - .env
     depends_on:
@@ -30,7 +30,7 @@ services:
       - pg_data:/var/lib/postgresql/data
 
   solr:
-    image: datagov/catalog.data.gov.solr
+    image: datagov/catalog.data.gov.solr:fcs
     ports:
       - "8983:8983"
     volumes:


### PR DESCRIPTION
Will tag builds on the fcs branch with `fcs` in dockerhub; will allow the builds to remain separate. `main` will still tag with `latest`.
Related to https://github.com/GSA/datagov-deploy/issues/2791