### PR TITLE
Bump dependencies

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -15,11 +15,11 @@ chardet==3.0.4
 -e git+https://github.com/GSA/ckanext-datagovcatalog.git@2225231e129e4aacb35939dcd2765ed7f9216bb1#egg=ckanext-datagovcatalog
 -e git+https://github.com/GSA/ckanext-datagovtheme.git@1853971076dc65c34bbf9864336c8de15bf9e6c9#egg=ckanext-datagovtheme
 -e git+https://github.com/GSA/ckanext-datajson.git@4ca1ca31cfcc23d6610c13693049fcfc83696d08#egg=ckanext-datajson
--e git+https://github.com/ckan/ckanext-dcat@dfeae13248b93fe542486262254cda7e627da2f6#egg=ckanext-dcat
+-e git+https://github.com/ckan/ckanext-dcat@c285382e0c893a2dea7005729156f8bd3348ec54#egg=ckanext-dcat
 ckanext-envvars==0.0.1
 -e git+https://github.com/GSA/ckanext-geodatagov.git@020e54d330c96f17f9ca6cd5429f2aa335ad37d0#egg=ckanext-geodatagov
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@f0b75cf965e477a84f044885b27880782a48969c#egg=ckanext-googleanalyticsbasic
--e git+https://github.com/ckan/ckanext-harvest.git@44bf78865ff49ff4313c22c6ece8c736e2e41f0f#egg=ckanext-harvest
+-e git+https://github.com/ckan/ckanext-harvest.git@e2e8acbb6d87d44663e92c5ff5cbd67401588c2d#egg=ckanext-harvest
 -e git+https://github.com/ckan/ckanext-qa.git@d7d384cb18a85243ea62ef0bcc76bc1775f1c806#egg=ckanext-qa
 -e git+https://github.com/davidread/ckanext-report.git@b67875b2a5b4c9b9ab2cf255f074226255ca9398#egg=ckanext-report
 -e git+https://github.com/keitaroinc/ckanext-saml2auth.git@d77d85349c7a6fcfa5a14c19a56b53eacf137a7c#egg=ckanext-saml2auth
@@ -81,7 +81,7 @@ pygments==2.5.2
 pylons==0.9.7
 pyopenssl==20.0.1
 pyparsing==2.4.7
--e git+https://github.com/GSA/pysaml2.git@c26a4893ff4c8d97e5f7994809ccb96a9d12caa3#egg=pysaml2
+-e git+https://github.com/GSA/pysaml2.git@ba144b7d5c804fd45808914e8562d1d26300c8a8#egg=pysaml2
 pysolr==3.8.0
 python-dateutil==1.5
 python-magic==0.4.15

--- a/requirements/poetry.lock
+++ b/requirements/poetry.lock
@@ -220,7 +220,7 @@ python-versions = "*"
 version = "1.1.1"
 
 [package.source]
-reference = "dfeae13248b93fe542486262254cda7e627da2f6"
+reference = "c285382e0c893a2dea7005729156f8bd3348ec54"
 type = "git"
 url = "https://github.com/ckan/ckanext-dcat"
 [[package]]
@@ -261,10 +261,10 @@ description = "Harvesting interface plugin for CKAN"
 name = "ckanext-harvest"
 optional = false
 python-versions = "*"
-version = "1.3.2"
+version = "1.3.3"
 
 [package.source]
-reference = "44bf78865ff49ff4313c22c6ece8c736e2e41f0f"
+reference = "e2e8acbb6d87d44663e92c5ff5cbd67401588c2d"
 type = "git"
 url = "https://github.com/ckan/ckanext-harvest.git"
 [[package]]
@@ -1010,7 +1010,7 @@ six = "*"
 s2repoze = ["paste", "zope.interface", "repoze.who"]
 
 [package.source]
-reference = "c26a4893ff4c8d97e5f7994809ccb96a9d12caa3"
+reference = "ba144b7d5c804fd45808914e8562d1d26300c8a8"
 type = "git"
 url = "https://github.com/GSA/pysaml2.git"
 [[package]]
@@ -1724,6 +1724,8 @@ lxml = [
     {file = "lxml-4.6.3-cp27-cp27m-win_amd64.whl", hash = "sha256:8157dadbb09a34a6bd95a50690595e1fa0af1a99445e2744110e3dca7831c4ee"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4"},
+    {file = "lxml-4.6.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51"},
+    {file = "lxml-4.6.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"},
     {file = "lxml-4.6.3-cp35-cp35m-win32.whl", hash = "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2"},
     {file = "lxml-4.6.3-cp35-cp35m-win_amd64.whl", hash = "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4"},
     {file = "lxml-4.6.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d2e35d7bf1c1ac8c538f88d26b396e73dd81440d59c1ef8522e1ea77b345ede4"},

--- a/requirements/pyproject.toml
+++ b/requirements/pyproject.toml
@@ -89,7 +89,7 @@ geomet = ">=0.2.0"
 future = ">=0.18.2"
 six = ">=1.15.0"
 
-# ckanext-pysaml2
+# ckanext-saml2auth
 # Using a patched 4.9 version due to a security issue: https://github.com/GSA/datagov-ckan-multi/issues/544
 pysaml2 = { git = "https://github.com/GSA/pysaml2.git", tag = "datagov/v4.9.0" }
 


### PR DESCRIPTION
https://github.com/gsa/datagov-deploy/issues/2845

Pick up latest patched version of pysaml2.
