### PR TITLE
Update requirements for pygments

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -15,11 +15,11 @@ chardet==3.0.4
 -e git+https://github.com/GSA/ckanext-datagovcatalog.git@2225231e129e4aacb35939dcd2765ed7f9216bb1#egg=ckanext-datagovcatalog
 -e git+https://github.com/GSA/ckanext-datagovtheme.git@1853971076dc65c34bbf9864336c8de15bf9e6c9#egg=ckanext-datagovtheme
 -e git+https://github.com/GSA/ckanext-datajson.git@4ca1ca31cfcc23d6610c13693049fcfc83696d08#egg=ckanext-datajson
--e git+https://github.com/ckan/ckanext-dcat@dfeae13248b93fe542486262254cda7e627da2f6#egg=ckanext-dcat
+-e git+https://github.com/ckan/ckanext-dcat@c285382e0c893a2dea7005729156f8bd3348ec54#egg=ckanext-dcat
 ckanext-envvars==0.0.1
 -e git+https://github.com/GSA/ckanext-geodatagov.git@020e54d330c96f17f9ca6cd5429f2aa335ad37d0#egg=ckanext-geodatagov
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@f0b75cf965e477a84f044885b27880782a48969c#egg=ckanext-googleanalyticsbasic
--e git+https://github.com/ckan/ckanext-harvest.git@44bf78865ff49ff4313c22c6ece8c736e2e41f0f#egg=ckanext-harvest
+-e git+https://github.com/ckan/ckanext-harvest.git@e2e8acbb6d87d44663e92c5ff5cbd67401588c2d#egg=ckanext-harvest
 -e git+https://github.com/ckan/ckanext-qa.git@d7d384cb18a85243ea62ef0bcc76bc1775f1c806#egg=ckanext-qa
 -e git+https://github.com/davidread/ckanext-report.git@b67875b2a5b4c9b9ab2cf255f074226255ca9398#egg=ckanext-report
 -e git+https://github.com/keitaroinc/ckanext-saml2auth.git@d77d85349c7a6fcfa5a14c19a56b53eacf137a7c#egg=ckanext-saml2auth
@@ -77,11 +77,11 @@ polib==1.0.7
 progressbar==2.3
 psycopg2==2.7.3.2
 pycparser==2.20
-pygments==2.5.2
+-e git+https://github.com/GSA/pygments.git@f9f800a18ed795f6d9579f0acf934f8103a964bf#egg=pygments
 pylons==0.9.7
 pyopenssl==20.0.1
 pyparsing==2.4.7
--e git+https://github.com/GSA/pysaml2.git@c26a4893ff4c8d97e5f7994809ccb96a9d12caa3#egg=pysaml2
+-e git+https://github.com/GSA/pysaml2.git@ba144b7d5c804fd45808914e8562d1d26300c8a8#egg=pysaml2
 pysolr==3.8.0
 python-dateutil==1.5
 python-magic==0.4.15

--- a/requirements/poetry.lock
+++ b/requirements/poetry.lock
@@ -220,7 +220,7 @@ python-versions = "*"
 version = "1.1.1"
 
 [package.source]
-reference = "dfeae13248b93fe542486262254cda7e627da2f6"
+reference = "c285382e0c893a2dea7005729156f8bd3348ec54"
 type = "git"
 url = "https://github.com/ckan/ckanext-dcat"
 [[package]]
@@ -261,10 +261,10 @@ description = "Harvesting interface plugin for CKAN"
 name = "ckanext-harvest"
 optional = false
 python-versions = "*"
-version = "1.3.2"
+version = "1.3.3"
 
 [package.source]
-reference = "44bf78865ff49ff4313c22c6ece8c736e2e41f0f"
+reference = "e2e8acbb6d87d44663e92c5ff5cbd67401588c2d"
 type = "git"
 url = "https://github.com/ckan/ckanext-harvest.git"
 [[package]]
@@ -927,11 +927,15 @@ version = "2.20"
 [[package]]
 category = "main"
 description = "Pygments is a syntax highlighting package written in Python."
-name = "pygments"
+name = "Pygments"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.5.2"
+python-versions = "*"
+version = "2.2.0.dev20210429"
 
+[package.source]
+reference = "f9f800a18ed795f6d9579f0acf934f8103a964bf"
+type = "git"
+url = "https://github.com/GSA/pygments.git"
 [[package]]
 category = "main"
 description = "Pylons Web Framework"
@@ -1010,7 +1014,7 @@ six = "*"
 s2repoze = ["paste", "zope.interface", "repoze.who"]
 
 [package.source]
-reference = "c26a4893ff4c8d97e5f7994809ccb96a9d12caa3"
+reference = "ba144b7d5c804fd45808914e8562d1d26300c8a8"
 type = "git"
 url = "https://github.com/GSA/pysaml2.git"
 [[package]]
@@ -1437,7 +1441,7 @@ test = ["zope.event"]
 testing = ["zope.event", "nose", "coverage"]
 
 [metadata]
-content-hash = "2eeda4988a636718c3e00a9ac9f20896c2f929517df8fe72c13a66de860eec38"
+content-hash = "76a38aa7edc1cf1341d4a310b850496a407ad6af10f6f1856e104e48c6e11d6d"
 lock-version = "1.0"
 python-versions = "^2.7"
 
@@ -1724,6 +1728,8 @@ lxml = [
     {file = "lxml-4.6.3-cp27-cp27m-win_amd64.whl", hash = "sha256:8157dadbb09a34a6bd95a50690595e1fa0af1a99445e2744110e3dca7831c4ee"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4"},
+    {file = "lxml-4.6.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51"},
+    {file = "lxml-4.6.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"},
     {file = "lxml-4.6.3-cp35-cp35m-win32.whl", hash = "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2"},
     {file = "lxml-4.6.3-cp35-cp35m-win_amd64.whl", hash = "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4"},
     {file = "lxml-4.6.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d2e35d7bf1c1ac8c538f88d26b396e73dd81440d59c1ef8522e1ea77b345ede4"},
@@ -1920,10 +1926,7 @@ pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
-pygments = [
-    {file = "Pygments-2.5.2-py2.py3-none-any.whl", hash = "sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b"},
-    {file = "Pygments-2.5.2.tar.gz", hash = "sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"},
-]
+Pygments = []
 pylons = [
     {file = "Pylons-0.9.7-py2.6.egg", hash = "sha256:6eafd95a83b170951165580c0f6bab030fe2b4e84cbcc59c622780cb691a7a95"},
     {file = "Pylons-0.9.7.tar.gz", hash = "sha256:36a62a184819ef01e65c865364f1b262299e6215ef55d8add6a1a258a9dd6933"},

--- a/requirements/pyproject.toml
+++ b/requirements/pyproject.toml
@@ -24,6 +24,7 @@ ckanext-qa = {git = "https://github.com/ckan/ckanext-qa.git" }
 ckanext-saml2auth = { git = "https://github.com/keitaroinc/ckanext-saml2auth.git", tag = "ckan-2.8" }
 ckanext-dcat = {git="https://github.com/ckan/ckanext-dcat" }
 webob = {git = "https://github.com/GSA/webob.git", branch = "ckan-patch" }
+pygments = {git = "https://github.com/GSA/pygments.git", branch = "datagov/v2.2.x" }
 # If you try to add and extension and it didn't work you should try `chown user:user -R .` because if you run docker as superuser and the as a regular user won't be able to add the folder for the new extension
 
 


### PR DESCRIPTION
Updated all requirements, but focus is on pygments fork (see [here](https://github.com/GSA/pygments/tree/datagov/v2.2.x)).

Related to https://github.com/GSA/datagov-deploy/issues/2713