### PR TITLE
add missing $DIR

### DIFF
--- a/ckan/setup/server_start.sh
+++ b/ckan/setup/server_start.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
 # Run web application
 exec newrelic-admin run-program gunicorn -c "$DIR/gunicorn.conf.py" --worker-class gevent --paste $CKAN_INI "$@"


### PR DESCRIPTION
fixed a bug introduced in https://github.com/GSA/catalog.data.gov/pull/289

Without it file gunicorn.conf.py could not be loaded.
