### PR TITLE
Remove unnecessary pg setup

### DIFF
--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,9 +1,6 @@
 FROM mdillon/postgis:10-alpine
 MAINTAINER Open Knowledge International
 
-# Allow connections; we don't map out any ports so only linked docker containers can connect
-RUN echo "host all  all    0.0.0.0/0  md5" >> /var/lib/postgresql/data/pg_hba.conf
-
 # Customize default user/pass/db
 ENV POSTGRES_DB ckan
 ENV POSTGRES_USER ckan


### PR DESCRIPTION
Gives the following errors on a new uninitialized DB:
db_1           | initdb: directory "/var/lib/postgresql/data" exists but is not empty
db_1           | If you want to create a new database system, either remove or empty
db_1           | the directory "/var/lib/postgresql/data" or run initdb
db_1           | with an argument other than "/var/lib/postgresql/data".

The setup for system access is unnecessary now, removing it leaves the `/data` folder empty and the initialization happens normally.