### PR TITLE
Update circleci-build-catalog-next.bash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,21 +47,22 @@ jobs:
     steps:
       - checkout
       - run:
-          name: tests 
+          name: tests
           command: make test-import-tool
-  
-  start_ckan_28:
+
+  # Test the shared CI setup script completes successfully
+  test_legacy_ci_script:
     machine:
       image: circleci/classic:201708-01
     steps:
       - checkout
       - run:
-          name: Start CKAN 2.8
+          name: Setup CI with legacy script
           command: |
             cp ckan/test-catalog-next.ini tools/ci-scripts/
             cd tools/ci-scripts
             ./circleci-build-catalog-next.bash
-  
+
   docker_publish_catalog:
     machine: true
     steps:
@@ -112,7 +113,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - start_ckan_28
+      - test_legacy_ci_script
       - deploy-sandbox:
           requires:
             - test

--- a/tools/ci-scripts/circleci-build-catalog-next.bash
+++ b/tools/ci-scripts/circleci-build-catalog-next.bash
@@ -22,6 +22,10 @@ CKAN_BRANCH="2.8"
 
 wget -O full_requirements.txt https://raw.githubusercontent.com/GSA/catalog.data.gov/fcs/ckan/requirements.txt
 wget https://raw.githubusercontent.com/$CKAN_ORG/ckan/$CKAN_BRANCH/test-core.ini
+# TODO link to bug upstream
+# Delete problematic test setting from CKAN test-core.ini
+sed -i '/^ckan.datastore.sqlsearch.allowed_functions_file\s*=/ d' test-core.ini
+
 wget https://raw.githubusercontent.com/$CKAN_ORG/ckan/$CKAN_BRANCH/ckan/config/who.ini
 
 echo "-----------------------------------------------------------------"

--- a/tools/ci-scripts/circleci-build-catalog-next.bash
+++ b/tools/ci-scripts/circleci-build-catalog-next.bash
@@ -18,6 +18,10 @@ wget -O full_requirements.txt https://raw.githubusercontent.com/GSA/catalog.data
 wget https://raw.githubusercontent.com/$CKAN_ORG/ckan/$CKAN_BRANCH/test-core.ini
 wget https://raw.githubusercontent.com/$CKAN_ORG/ckan/$CKAN_BRANCH/ckan/config/who.ini
 
+# TODO link to upstream issue
+# Stub this missing file
+touch ckanext/datastore/tests/allowed_functions.txt
+
 echo "-----------------------------------------------------------------"
 echo "Installing CKAN and its Python dependencies..."
 

--- a/tools/ci-scripts/circleci-build-catalog-next.bash
+++ b/tools/ci-scripts/circleci-build-catalog-next.bash
@@ -20,6 +20,7 @@ wget https://raw.githubusercontent.com/$CKAN_ORG/ckan/$CKAN_BRANCH/ckan/config/w
 
 # TODO link to upstream issue
 # Stub this missing file
+mkdir -p ckanext/datastore/tests/
 touch ckanext/datastore/tests/allowed_functions.txt
 
 echo "-----------------------------------------------------------------"

--- a/tools/ci-scripts/circleci-build-catalog-next.bash
+++ b/tools/ci-scripts/circleci-build-catalog-next.bash
@@ -14,14 +14,9 @@ echo "Downliading settings"
 CKAN_ORG="ckan"
 CKAN_BRANCH="2.8"
 
-wget -O full_requirements.txt https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/requirements.txt
+wget -O full_requirements.txt https://raw.githubusercontent.com/GSA/catalog.data.gov/fcs/ckan/requirements.txt
 wget https://raw.githubusercontent.com/$CKAN_ORG/ckan/$CKAN_BRANCH/test-core.ini
 wget https://raw.githubusercontent.com/$CKAN_ORG/ckan/$CKAN_BRANCH/ckan/config/who.ini
-
-# TODO link to upstream issue
-# Stub this missing file
-mkdir -p ckanext/datastore/tests/
-touch ckanext/datastore/tests/allowed_functions.txt
 
 echo "-----------------------------------------------------------------"
 echo "Installing CKAN and its Python dependencies..."

--- a/tools/ci-scripts/circleci-build-catalog-next.bash
+++ b/tools/ci-scripts/circleci-build-catalog-next.bash
@@ -1,4 +1,10 @@
 #!/bin/bash
+# This shared script is considered legacy. It is used to configure a VM for
+# testing in a catalog.data.gov environment (simliar configuration and
+# extensions).
+#
+# TODO delete this once extensions are CKAN 2.9 compatible
+
 set -e
 echo "Building catalog next environment..."
 
@@ -10,7 +16,7 @@ sudo apt-get install solr-jetty libcommons-fileupload-java libpq-dev postgresql 
  	 python-dev libxml2-dev libxslt1-dev libgeos-c1 redis-server
 
 echo "-----------------------------------------------------------------"
-echo "Downliading settings"
+echo "Downloading settings"
 CKAN_ORG="ckan"
 CKAN_BRANCH="2.8"
 

--- a/tools/ci-scripts/circleci-build-catalog-next.bash
+++ b/tools/ci-scripts/circleci-build-catalog-next.bash
@@ -14,7 +14,7 @@ echo "Downliading settings"
 CKAN_ORG="ckan"
 CKAN_BRANCH="2.8"
 
-wget -O full_requirements.txt https://raw.githubusercontent.com/GSA/catalog.data.gov/master/ckan/requirements.txt
+wget -O full_requirements.txt https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/requirements.txt
 wget https://raw.githubusercontent.com/$CKAN_ORG/ckan/$CKAN_BRANCH/test-core.ini
 wget https://raw.githubusercontent.com/$CKAN_ORG/ckan/$CKAN_BRANCH/ckan/config/who.ini
 
@@ -40,7 +40,7 @@ echo "Setting up Solr..."
 # see https://github.com/ckan/ckan/issues/2972
 sed -i -e 's/solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' test-core.ini
 printf "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
-sudo wget -O /etc/solr/conf/schema.xml https://raw.githubusercontent.com/GSA/catalog.data.gov/master/solr/schema.xml
+sudo wget -O /etc/solr/conf/schema.xml https://raw.githubusercontent.com/GSA/catalog.data.gov/fcs/solr/schema.xml
 sudo service jetty restart
 
 echo "-----------------------------------------------------------------"


### PR DESCRIPTION
This shared script is used for the legacy "travis-build script" style tests in other repos. Since these are legacy and are only testing CKAN 2.8 with our legacy catalog/inventory setup, we should be using the fcs branch instead of master (or main) which are targeting cloud.gov.