### PR TITLE
Solr Upgrade

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,11 +1,11 @@
-FROM solr:6.2-alpine
+FROM solr:6.6.6
 MAINTAINER Open Knowledge
 
 # Enviroment
 ENV SOLR_CORE ckan
 ENV CKAN_VERSION dev-v2.7
 
-# User
+# Set user to root for initial configuration
 USER root
 
 # Create Directories
@@ -15,15 +15,19 @@ RUN mkdir -p /opt/solr/server/solr/$SOLR_CORE/data
 # Adding Files
 ADD solrconfig.xml \
 schema.xml \
-https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.0.0/solr/server/solr/configsets/basic_configs/conf/currency.xml \
-https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.0.0/solr/server/solr/configsets/basic_configs/conf/synonyms.txt \
-https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.0.0/solr/server/solr/configsets/basic_configs/conf/stopwords.txt \
-https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.0.0/solr/server/solr/configsets/basic_configs/conf/protwords.txt \
-https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.0.0/solr/server/solr/configsets/data_driven_schema_configs/conf/elevate.xml \
+https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.6.6/solr/server/solr/configsets/basic_configs/conf/currency.xml \
+https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.6.6/solr/server/solr/configsets/basic_configs/conf/synonyms.txt \
+https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.6.6/solr/server/solr/configsets/basic_configs/conf/stopwords.txt \
+https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.6.6/solr/server/solr/configsets/basic_configs/conf/protwords.txt \
+https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.6.6/solr/server/solr/configsets/data_driven_schema_configs/conf/elevate.xml \
 /opt/solr/server/solr/$SOLR_CORE/conf/
 
 # Create Core.properties
 RUN echo name=$SOLR_CORE > /opt/solr/server/solr/$SOLR_CORE/core.properties
 
 # Giving ownership to Solr
-RUN chown -R $SOLR_USER:$SOLR_USER /opt/solr/server/solr/$SOLR_CORE
+RUN mkdir /opt/solr/server/solr/$SOLR_CORE/data/index
+RUN chown -R $SOLR_USER:$SOLR_USER /opt/solr/server/solr/
+
+# Set user to 'solr' for to comply with solr security
+USER solr


### PR DESCRIPTION
Upgraded version of solr for xxe patch

To replace https://github.com/GSA/catalog.data.gov/pull/315

The upgraded version of solr does fix: GSA/datagov-deploy#3245

A demonstration can be shown, but with the older version of solr, external entity resolution works and with the new version, external entity resolution becomes unsupported.

This may be an immature pull request depending on the two following reasons:

1. Updating the config.xml(s) from 6.0.0 to 6.6.6 was only done because it seems appropriate, I'm not sure if those were frozen at 6.0.0 for a reason.
1. I didn't make a test to show the vulnerability was fixed. It is possible, but I didn't think about doing it before re-reading the Contributing best practices. Semi-related, I'm also not sure about sensitivity of information, so I left it out until we talk about it.
