### PR TITLE
Bugfix/solr libraries update

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:6.6.6
+FROM solr:6.6.6-slim
 MAINTAINER Open Knowledge
 
 # Enviroment
@@ -21,6 +21,19 @@ https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.6.6/
 https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.6.6/solr/server/solr/configsets/basic_configs/conf/protwords.txt \
 https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.6.6/solr/server/solr/configsets/data_driven_schema_configs/conf/elevate.xml \
 /opt/solr/server/solr/$SOLR_CORE/conf/
+
+# Fix Issue https://github.com/GSA/datagov-deploy/issues/3285
+# Update the angularjs library files
+ADD https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.8.2/angular.min.js \
+https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.8.2/angular.js \
+https://cdnjs.cloudflare.com/ajax/libs/angular-route/1.8.2/angular-route.js \
+https://cdnjs.cloudflare.com/ajax/libs/angular-route/1.8.2/angular-route.min.js \
+https://cdnjs.cloudflare.com/ajax/libs/angular-sanitize/1.8.2/angular-sanitize.js \
+https://cdnjs.cloudflare.com/ajax/libs/angular-sanitize/1.8.2/angular-sanitize.min.js \
+https://cdnjs.cloudflare.com/ajax/libs/angular-cookies/1.8.2/angular-cookies.js \
+https://cdnjs.cloudflare.com/ajax/libs/angular-cookies/1.8.2/angular-cookies.min.js \
+https://cdnjs.cloudflare.com/ajax/libs/angular-resource/1.8.2/angular-resource.min.js \
+/opt/solr/server/solr-webapp/webapp/libs/
 
 # Fix Issue https://github.com/GSA/datagov-deploy/issues/3283
 # Disable directory listing

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -51,6 +51,9 @@ ADD https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.11/jstree.min.js \
 /opt/solr/server/solr-webapp/webapp/libs/jquery.jstree.js
 ADD https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.11/jstree.min.js \
 /opt/solr/server/solr-webapp/webapp/js/lib/jquery.jstree.js
+RUN chmod -R 644 /opt/solr/server/solr-webapp/webapp/libs/*.js
+RUN chmod -R 644 /opt/solr/server/solr-webapp/webapp/js/lib/*.js
+RUN chown -R $SOLR_USER:$SOLR_USER /opt/solr/server/solr-webapp/webapp/
 
 # Fix Issue https://github.com/GSA/datagov-deploy/issues/3283
 # Disable directory listing

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -22,6 +22,7 @@ https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.6.6/
 https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.6.6/solr/server/solr/configsets/data_driven_schema_configs/conf/elevate.xml \
 /opt/solr/server/solr/$SOLR_CORE/conf/
 
+
 # Fix Issue https://github.com/GSA/datagov-deploy/issues/3285
 # Update the angularjs library files
 ADD https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.8.2/angular.min.js \
@@ -35,25 +36,35 @@ https://cdnjs.cloudflare.com/ajax/libs/angular-cookies/1.8.2/angular-cookies.min
 https://cdnjs.cloudflare.com/ajax/libs/angular-resource/1.8.2/angular-resource.min.js \
 /opt/solr/server/solr-webapp/webapp/libs/
 
+
 # Fix Issue 
 # Update jQuery library files
-# 'chosen.jquery', 'jquery.cookie', 'jquery.blockui', 'jquery.timeago',
-# 'jquery.sammy', 'jquery.ajaxfileupload' NO known vulnerabilities
-# 'jquery.form' ALL versions vulnerable -- https://snyk.io/vuln/npm:jquery-form
+#   'chosen.jquery', 'jquery.cookie', 'jquery.blockui', 'jquery.timeago',
+#   'jquery.sammy', 'jquery.ajaxfileupload' NO known vulnerabilities
+#   'jquery.form' ALL versions vulnerable -- https://snyk.io/vuln/npm:jquery-form
 # 'jquery.min.js' is used in two place (1x each), but it's easier to keep the
 # old name than to do an in-place string replacement with perl like below
 ADD https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js \
-/opt/solr/server/solr-webapp/webapp/libs/jquery-2.1.3.min.js
+/opt/solr/server/solr-webapp/webapp/libs/jquery-3.6.0.min.js
 ADD https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js \
-/opt/solr/server/solr-webapp/webapp/js/lib/jquery-1.7.2.min.js
+/opt/solr/server/solr-webapp/webapp/js/lib/jquery-3.6.0.min.js
 # https://snyk.io/vuln/npm:jstree
 ADD https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.11/jstree.min.js \
 /opt/solr/server/solr-webapp/webapp/libs/jquery.jstree.js
 ADD https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.11/jstree.min.js \
 /opt/solr/server/solr-webapp/webapp/js/lib/jquery.jstree.js
+# Make sure user 'solr' owns and has permissions for the new libraries
 RUN chmod -R 644 /opt/solr/server/solr-webapp/webapp/libs/*.js
 RUN chmod -R 644 /opt/solr/server/solr-webapp/webapp/js/lib/*.js
 RUN chown -R $SOLR_USER:$SOLR_USER /opt/solr/server/solr-webapp/webapp/
+# Update references to jquery
+RUN sed -i 's/jquery-2.1.3.min.js/jquery-3.6.0.min.js/' \
+    /opt/solr/server/solr-webapp/webapp/index.html
+RUN sed -i 's/jquery-1.7.2.min.js/jquery-3.6.0.min.js/' \
+    /opt/solr/example/files/conf/velocity/head.vm
+RUN sed -i 's/jquery-1.7.2.min.js/jquery-3.6.0.min.js/' \
+    /opt/solr/server/solr/configsets/sample_techproducts_configs/conf/velocity/head.vm
+
 
 # Fix Issue https://github.com/GSA/datagov-deploy/issues/3283
 # Disable directory listing
@@ -62,10 +73,11 @@ RUN perl -0777  -i -pe 's/ \
     <param-name>dirAllowed<\/param-name>\n      <param-value>false<\/param-value>/igs' \
     /opt/solr/server/etc/webdefault.xml
 
+
 # Create Core.properties
 RUN echo name=$SOLR_CORE > /opt/solr/server/solr/$SOLR_CORE/core.properties
 
-# Giving ownership to Solr
+# Giving ownership to user 'solr'
 RUN mkdir /opt/solr/server/solr/$SOLR_CORE/data/index
 RUN chown -R $SOLR_USER:$SOLR_USER /opt/solr/server/solr/
 

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -35,6 +35,23 @@ https://cdnjs.cloudflare.com/ajax/libs/angular-cookies/1.8.2/angular-cookies.min
 https://cdnjs.cloudflare.com/ajax/libs/angular-resource/1.8.2/angular-resource.min.js \
 /opt/solr/server/solr-webapp/webapp/libs/
 
+# Fix Issue 
+# Update jQuery library files
+# 'chosen.jquery', 'jquery.cookie', 'jquery.blockui', 'jquery.timeago',
+# 'jquery.sammy', 'jquery.ajaxfileupload' NO known vulnerabilities
+# 'jquery.form' ALL versions vulnerable -- https://snyk.io/vuln/npm:jquery-form
+# 'jquery.min.js' is used in two place (1x each), but it's easier to keep the
+# old name than to do an in-place string replacement with perl like below
+ADD https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js \
+/opt/solr/server/solr-webapp/webapp/libs/jquery-2.1.3.min.js
+ADD https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js \
+/opt/solr/server/solr-webapp/webapp/js/lib/jquery-1.7.2.min.js
+# https://snyk.io/vuln/npm:jstree
+ADD https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.11/jstree.min.js \
+/opt/solr/server/solr-webapp/webapp/libs/jquery.jstree.js
+ADD https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.11/jstree.min.js \
+/opt/solr/server/solr-webapp/webapp/js/lib/jquery.jstree.js
+
 # Fix Issue https://github.com/GSA/datagov-deploy/issues/3283
 # Disable directory listing
 RUN perl -0777  -i -pe 's/ \


### PR DESCRIPTION
Replace https://github.com/GSA/catalog.data.gov/pull/320

> Updated libraries for both GSA/datagov-deploy#3284 and GSA/datagov-deploy#3285.. While not ideal, this solution was taken for minimal impact to overall solr operation. All vulnerabilities were referenced and online cdn's were referenced to download updated files. Solr was using cdnjs.cloudflare.com/ajax/libs for some resources, so I used that link to procure additional files.
> 
> Additionally, I switched the solr version to 6.6.6-slim for greater portability amid memory and storage issues. @adborden attempted to use this version originally since solr was previously on 6.2-alpine (#298). I ran all tests and cross-referenced the "Image Variants" on https://hub.docker.com/_/solr. Unless there is some obvious reason we need the common packages, I think it's safe to go with the slim version. This can be easily reverted before the pull request is merged.