### PR TITLE
FCS: Update datagovtheme for organization page fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ quick-bat-test:
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit test
 
 update-dependencies:
-	docker-compose run --rm -T ckan freeze-requirements.sh $(shell id -u) $(shell id -g)
+	docker-compose run --rm -T ckan /app/ckan/freeze-requirements.sh $(shell id -u) $(shell id -g)
 
 up:
 	docker-compose up

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -8,7 +8,7 @@ cffi==1.14.6
 chardet==3.0.4
 ckan @ git+https://github.com/ckan/ckan.git@e8b7970423e2cce9731441edd13f7fcfd3be58e9
 -e git+https://github.com/GSA/ckanext-datagovcatalog.git@64e65702ae1eb5e46d9f37139dc4044c0f253526#egg=ckanext_datagovcatalog
--e git+https://github.com/GSA/ckanext-datagovtheme.git@97d90780b736f17aa75607a36ef4d57057635453#egg=ckanext_datagovtheme
+-e git+https://github.com/GSA/ckanext-datagovtheme.git@29d7454afd516b63cdabb41e7b1dfd4f69daffd4#egg=ckanext_datagovtheme
 -e git+https://github.com/GSA/ckanext-datajson.git@34b003239cb80cd5edc758855c3cf6b5e04fbb6a#egg=ckanext_datajson
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@c4e7319aff55e5315831b28e918299092f2d5805
 ckanext-envvars @ git+https://github.com/GSA/ckanext-envvars.git@33f7e190ab332244cb961a425e09af592d9b647b


### PR DESCRIPTION
Only update datagovtheme to fix organization link,

![image](https://user-images.githubusercontent.com/85196563/133337907-8f5ebdf9-f4f1-46d7-a8e1-05f314fb429f.png)
