### PR TITLE
Feature/test harvest private

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -12,7 +12,7 @@ ckan @ git+https://github.com/ckan/ckan.git@e8b7970423e2cce9731441edd13f7fcfd3be
 -e git+https://github.com/GSA/ckanext-datajson.git@34b003239cb80cd5edc758855c3cf6b5e04fbb6a#egg=ckanext_datajson
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@c4e7319aff55e5315831b28e918299092f2d5805
 ckanext-envvars @ git+https://github.com/GSA/ckanext-envvars.git@33f7e190ab332244cb961a425e09af592d9b647b
--e git+https://github.com/GSA/ckanext-geodatagov.git@0853bee402148f7ccabc8f37ca8c10088e6dcb42#egg=ckanext_geodatagov
+-e git+https://github.com/GSA/ckanext-geodatagov.git@7f4307f07aee935f7168c4d4eab968423c111485#egg=ckanext_geodatagov
 ckanext-googleanalyticsbasic @ git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@10ebfe25744b0f6e4cb1294f4a16654eb13119f6
 -e git+https://github.com/GSA/ckanext-harvest.git@fd5a6b739666a62cff486873877eef10523aec1a#egg=ckanext_harvest
 -e git+https://github.com/gsa/ckanext-spatial.git@36981c39d624685bc85b84f801f2a2d6eaea67f6#egg=ckanext_spatial

--- a/e2e/cypress/integration/000_harvest.spec.js
+++ b/e2e/cypress/integration/000_harvest.spec.js
@@ -50,13 +50,6 @@ describe('Harvest', () => {
         cy.location('pathname').should('eq', '/harvest/' + dataJsonHarvestSoureName)
     })
 
-    it('Keeps the Dataset visilibity flag', () => {
-        // Go to previously created harvest source
-        cy.visit(`/harvest/edit/${dataJsonHarvestSourceName}`)
-
-        cy.get('#field-private_datasets').find(':selected').contains('False')
-    })
-
     it('Create a datajson harvest source INVALID', () => {
         cy.visit('/organization/'+harvestOrg)
         // Hide flask debug toolbar
@@ -104,6 +97,13 @@ describe('Harvest', () => {
            false)
         // harvestTitle must not contain spaces, otherwise the URL redirect will not confirm
         cy.location('pathname').should('eq', '/harvest/' + wafIsoHarvestSourceName)
+    })
+
+    it('Keeps the Dataset visilibity flag', () => {
+        // Go to previously created harvest source
+        cy.visit(`/harvest/edit/${wafIsoHarvestSourceName}`)
+
+        cy.get('#field-private_datasets').find(':selected').contains('Public')
     })
 
     it('Start WAF ISO Harvest Job', () => {

--- a/e2e/cypress/integration/000_harvest.spec.js
+++ b/e2e/cypress/integration/000_harvest.spec.js
@@ -43,12 +43,18 @@ describe('Harvest', () => {
                         dataJsonHarvestSoureName,
                         'cypress test datajson',
                         'datajson',
-                        harvestOrg,
-                        true,
+                        'False',
                         false)
 
         // harvestTitle must not contain spaces, otherwise the URL redirect will not confirm
         cy.location('pathname').should('eq', '/harvest/' + dataJsonHarvestSoureName)
+    })
+
+    it('Keeps the Dataset visilibity flag', () => {
+        // Go to previously created harvest source
+        cy.visit(`/harvest/edit/${dataJsonHarvestSourceName}`)
+
+        cy.get('#field-private_datasets').find(':selected').contains('False')
     })
 
     it('Create a datajson harvest source INVALID', () => {
@@ -63,8 +69,7 @@ describe('Harvest', () => {
                         'invalid datajson',
                         'invalid datajson',
                         'datajson',
-                        harvestOrg,
-                        true,
+                        'False',
                         true)
         cy.contains('URL: Missing value')
     })
@@ -95,8 +100,7 @@ describe('Harvest', () => {
            wafIsoHarvestSourceName,
            'cypress test waf iso',
            'waf',
-           harvestOrg,
-           true,
+           'False',
            false)
         // harvestTitle must not contain spaces, otherwise the URL redirect will not confirm
         cy.location('pathname').should('eq', '/harvest/' + wafIsoHarvestSourceName)

--- a/e2e/cypress/support/command.js
+++ b/e2e/cypress/support/command.js
@@ -123,20 +123,15 @@ Cypress.Commands.add('delete_dataset', (datasetName) => {
 })
 
 
-Cypress.Commands.add('create_harvest_source', (dataSourceUrl, harvestTitle, harvestDesc, harvestType, org, harvestTest, invalidTest) => {
+Cypress.Commands.add('create_harvest_source', (dataSourceUrl, harvestTitle, harvestDesc, harvestType, harvestPrivate, invalidTest) => {
     /**
      * Method to create a new CKAN harvest source via the CKAN harvest form
      * :PARAM dataSourceUrl String: URL to source the data that will be harvested
      * :PARAM harvestTitle String: Title of the organization's harvest
      * :PARAM harvestDesc String: Description of the harvest being created
      * :PARAM harvestType String: Harvest source type. Ex: waf, datajson
-     * :PARAM org String: Organization that is creating the harvest source
-     * :PARAM harvestTest Boolean: Determines if to use UI in harvest source creation test or to follow the UI to create a source
      * :RETURN null:
      */
-    if (!harvestTest) {
-        cy.visit('/harvest/new')
-    }
     if (!invalidTest) {
         cy.get('#field-url').type(dataSourceUrl)
     }
@@ -158,8 +153,7 @@ Cypress.Commands.add('create_harvest_source', (dataSourceUrl, harvestTitle, harv
         cy.get('[type="radio"]').check('iso19139ngdc')
     }
 
-    // Set harvest to be public always, per best practices
-    cy.get('#field-private_datasets').select('False')
+    cy.get('#field-private_datasets').select(harvestPrivate)
     
     cy.get('input[name=save]').click()
 })

--- a/e2e/cypress/support/command.js
+++ b/e2e/cypress/support/command.js
@@ -153,6 +153,9 @@ Cypress.Commands.add('create_harvest_source', (dataSourceUrl, harvestTitle, harv
         cy.get('[type="radio"]').check('iso19139ngdc')
     }
 
+    // Validate private_datasets defaults to Private
+    cy.get('#field-private_datasets').find(':selected').contains('Private')
+
     cy.get('#field-private_datasets').select(harvestPrivate)
     
     cy.get('input[name=save]').click()


### PR DESCRIPTION
This should evaluate if a harvest source is created to be public that the config "stays", and when revisiting the edit page the public setting is still set.

This depends on https://github.com/GSA/ckanext-geodatagov/pull/193

The tests before ^^ changes are brought in should fail.

This is related to https://github.com/GSA/datagov-deploy/issues/897