### PR TITLE
Upgrade ckanext-spatial

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -15,7 +15,7 @@ ckanext-envvars @ git+https://github.com/GSA/ckanext-envvars.git@33f7e190ab33224
 -e git+https://github.com/GSA/ckanext-geodatagov.git@bc700f671cd1d890db265c65f5db1cba121297f4#egg=ckanext_geodatagov
 ckanext-googleanalyticsbasic @ git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@c6a425d5e14d658c0fa3661fdc4423162161c3f4
 -e git+https://github.com/GSA/ckanext-harvest.git@a418ed4a8b91feefc9f91bfce6e03a8af5c83c36#egg=ckanext_harvest
--e git+https://github.com/gsa/ckanext-spatial.git@36981c39d624685bc85b84f801f2a2d6eaea67f6#egg=ckanext_spatial
+-e git+https://github.com/gsa/ckanext-spatial.git@964c65284e8105bf6823457ee8053ecc978d591d#egg=ckanext_spatial
 ckantoolkit==0.0.3
 click==7.1.2
 cryptography==35.0.0

--- a/e2e/cypress/integration/spatial.spec.js
+++ b/e2e/cypress/integration/spatial.spec.js
@@ -1,0 +1,30 @@
+describe('Spatial', () => {
+    it('Can search geographies by name', () => {
+        cy.request('/api/3/action/location_search?q=california').should((response) => {
+            expect(response.body).to.have.property('success', true);
+            expect(response.body.result[0]).to.have.property('text', 'California');
+        });
+    });
+    it('Can put a package in an organization', () => {
+        const group_name = 'climate';
+        cy.logout();
+        cy.login();
+        cy.delete_group(group_name);
+        cy.create_group(group_name, "Climate Group");
+        cy.request({
+            url: '/api/action/package_patch',
+            method: 'POST',
+            body: {
+                "id": "nefsc-2000-spring-bottom-trawl-survey-al0002-ek500",
+                "groups": [{"name": group_name}]
+            }
+        }).should((response) => {
+            expect(response.body).to.have.property('success', true);
+            expect(response.body.result.groups[0]).to.have.property("name", "climate");
+
+            // Cleanup
+            cy.delete_group(group_name);
+            cy.logout();
+        })
+    })
+});

--- a/e2e/cypress/integration/spatial_search.spec.js
+++ b/e2e/cypress/integration/spatial_search.spec.js
@@ -1,8 +1,0 @@
-describe('Spatial Search', () => {
-    it('Can search geographies by name', () => {
-        cy.request('/api/3/action/location_search?q=california').should((response) => {
-            expect(response.body).to.have.property('success', true);
-            expect(response.body.result[0]).to.have.property('text', 'California');
-        });
-    });
-});

--- a/e2e/cypress/support/command.js
+++ b/e2e/cypress/support/command.js
@@ -39,6 +39,10 @@ Cypress.Commands.add('login', (userName, password, loginTest) => {
     cy.get('.btn-primary').eq(1).click()
 })
 
+Cypress.Commands.add('logout', () => {
+    cy.clearCookies();
+})
+
 Cypress.Commands.add('create_organization_ui', (orgName, orgDesc) => {
     /**
      * Method to fill out the form to create a CKAN organization
@@ -78,6 +82,46 @@ Cypress.Commands.add('create_organization', (orgName, orgDesc) => {
             "approval_status": "approved",
             "state": "active",
             "name": orgName
+        }
+    })
+})
+
+
+Cypress.Commands.add('create_group', (groupName, groupDesc) => {
+    /**
+     * Method to create organization via CKAN API
+     * :PARAM groupName String: Name of the organization being created
+     * :PARAM groupDesc String: Description of the organization being created
+     * :RETURN null:
+     */
+
+     cy.request({
+        url: '/api/action/group_create',
+        method: 'POST',
+        body: {
+            "description": groupDesc,
+            "title": groupName,
+            "approval_status": "approved",
+            "state": "active",
+            "name": groupName
+        }
+    })
+})
+
+Cypress.Commands.add('delete_group', (groupName) => {
+    /**
+     * Method to create organization via CKAN API
+     * :PARAM groupName String: Name of the organization being created
+     * :PARAM groupDesc String: Description of the organization being created
+     * :RETURN null:
+     */
+
+     cy.request({
+        url: '/api/action/group_purge',
+        method: 'POST',
+        failOnStatusCode: false,
+        body: {
+            "id": groupName
         }
     })
 })


### PR DESCRIPTION
Test that a spatial harvested dataset with bad tags is still editable,
and can be added to a group.

Related to https://github.com/GSA/ckanext-spatial/pull/12 & https://github.com/GSA/datagov-deploy/issues/2413