### PR TITLE
Pin geodatagov

### DIFF
--- a/requirements/pyproject.toml
+++ b/requirements/pyproject.toml
@@ -13,7 +13,7 @@ ckanext-archiver = {git = "https://github.com/ckan/ckanext-archiver.git"}
 ckanext-datagovtheme = {git = "https://github.com/GSA/ckanext-datagovtheme.git", branch = "main" }
 ckanext-datajson = {git = "https://github.com/GSA/ckanext-datajson.git", branch = "main" }
 ckanext-envvars = "*"
-ckanext-geodatagov = {git = "https://github.com/GSA/ckanext-geodatagov.git", branch = "main" }
+ckanext-geodatagov = {git = "https://github.com/GSA/ckanext-geodatagov.git", rev = "ded11ffd3e4c97b8d418e45bfeeea0c3f4f10796" }
 ckanext-harvest = {git = "https://github.com/ckan/ckanext-harvest.git" }
 # ckanext-harvest = {git = "https://github.com/GSA/ckanext-harvest.git", branch = "datagov-catalog" }
 ckanext-report = {git = "https://github.com/ckan/ckanext-report.git" }


### PR DESCRIPTION
Pin FCS branch with old geodatagov version, so that it can continue to work with the FGDC2ISO external transformation service.

Related to https://github.com/GSA/datagov-deploy/issues/2917