### PR TITLE
pin ckanext-harvest before upstream PR merge

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -7,7 +7,7 @@ billiard==3.3.0.23
 bleach==3.3.0
 boto==2.49.0
 celery==3.1.25
-certifi==2021.5.30
+certifi==2021.10.8
 cffi==1.12.3
 chardet==3.0.4
 -e git+https://github.com/ckan/ckan.git@e50b79651090c5d5946660a4107915c5d59dda86#egg=ckan
@@ -19,7 +19,7 @@ chardet==3.0.4
 ckanext-envvars==0.0.1
 -e git+https://github.com/GSA/ckanext-geodatagov.git@ded11ffd3e4c97b8d418e45bfeeea0c3f4f10796#egg=ckanext-geodatagov
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@c6a425d5e14d658c0fa3661fdc4423162161c3f4#egg=ckanext-googleanalyticsbasic
--e git+https://github.com/ckan/ckanext-harvest.git@63701adaba22af6c82f699aa0d9c045ced9be4a3#egg=ckanext-harvest
+-e git+https://github.com/ckan/ckanext-harvest.git@d91ea66cf083b6618c5dab7ba56f6d7a8b468378#egg=ckanext-harvest
 -e git+https://github.com/ckan/ckanext-qa.git@d7d384cb18a85243ea62ef0bcc76bc1775f1c806#egg=ckanext-qa
 -e git+https://github.com/ckan/ckanext-report.git@82af48608b99e7176f1d76f70e59fcfdadf11dfd#egg=ckanext-report
 -e git+https://github.com/keitaroinc/ckanext-saml2auth.git@d77d85349c7a6fcfa5a14c19a56b53eacf137a7c#egg=ckanext-saml2auth

--- a/requirements/poetry.lock
+++ b/requirements/poetry.lock
@@ -121,7 +121,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2021.5.30"
+version = "2021.10.8"
 
 [[package]]
 category = "main"
@@ -267,7 +267,7 @@ python-versions = "*"
 version = "1.3.3"
 
 [package.source]
-reference = "63701adaba22af6c82f699aa0d9c045ced9be4a3"
+reference = "d91ea66cf083b6618c5dab7ba56f6d7a8b468378"
 type = "git"
 url = "https://github.com/ckan/ckanext-harvest.git"
 [[package]]
@@ -933,7 +933,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 name = "Pygments"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.5.2.dev20211005"
+version = "2.5.2.dev20211020"
 
 [package.source]
 reference = "f6ccbc8c73b6b0a3c86ba7f1cfc36ac98ff5f122"
@@ -1444,7 +1444,7 @@ test = ["zope.event"]
 testing = ["zope.event", "nose", "coverage"]
 
 [metadata]
-content-hash = "0fb6592863a86ecbc6d8db63ab39646dfb0f139c8dff6536162fbdcebc3a6cc7"
+content-hash = "dd414812d4f13b142df6b671e6064e7815e7412099f8882d92d11e6381410951"
 lock-version = "1.0"
 python-versions = "^2.7"
 
@@ -1490,8 +1490,8 @@ celery = [
     {file = "celery-3.1.25.tar.gz", hash = "sha256:6ced63033bc663e60c992564954dbb5c84c43899f7f1a04b739957350f6b55f3"},
 ]
 certifi = [
-    {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
-    {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
 cffi = [
     {file = "cffi-1.12.3-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:5662ad4e4e84f1eaa8efce5da695c5d2e229c563f9d5ce5b0113f71321bcf753"},

--- a/requirements/pyproject.toml
+++ b/requirements/pyproject.toml
@@ -14,7 +14,7 @@ ckanext-datagovtheme = {git = "https://github.com/GSA/ckanext-datagovtheme.git",
 ckanext-datajson = {git = "https://github.com/GSA/ckanext-datajson.git", branch = "main" }
 ckanext-envvars = "*"
 ckanext-geodatagov = {git = "https://github.com/GSA/ckanext-geodatagov.git", rev = "ded11ffd3e4c97b8d418e45bfeeea0c3f4f10796" }
-ckanext-harvest = {git = "https://github.com/ckan/ckanext-harvest.git" }
+ckanext-harvest = {git = "https://github.com/ckan/ckanext-harvest.git", rev = "d91ea66cf083b6618c5dab7ba56f6d7a8b468378" }
 # ckanext-harvest = {git = "https://github.com/GSA/ckanext-harvest.git", branch = "datagov-catalog" }
 ckanext-report = {git = "https://github.com/ckan/ckanext-report.git" }
 # Pin ckanext-spatial for csw harvest on ckan2.8


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/3480

A bug was introduced on https://github.com/ckan/ckanext-harvest/issues/469. It seems to only affect FCS branch running on CKAN core 2.8. Put a temporary pin on it until fixing PR is approved. 