### PR TITLE
Save cypress videos and screenshots

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -16,6 +16,14 @@ jobs:
         run: make build
       - name: test
         run: make test
+      - name: cypress-artifacs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-artifacts
+          path: |
+            ./e2e/cypress/screenshots/
+            ./e2e/cypress/videos/
 
   test_importer:
     name: test importer


### PR DESCRIPTION
This should load the artifacts as a zip to the failing github action to review if needed. Cypress log output is very vague, this will help greatly in debugging future failures. Currently it only does this on failure to keep things clean, but we could save them on every test if we wanted to...

You should be able to find this either on the "Checks" tab of a PR that has the failing test (near the "Rerun all jobs" dropdown) or on the GitHub Action summary page (see screenshot for DOI example).
![image](https://user-images.githubusercontent.com/26980513/138159069-ae5f0cee-4dfa-4dde-ae5a-8197bb2fb003.png)
