### PR TITLE
Use upstream ckanext-harvest

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -8,7 +8,7 @@ ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@master
 ckanext-envvars @ git+https://github.com/GSA/ckanext-envvars.git@main
 -e git+https://github.com/GSA/ckanext-geodatagov.git@main#egg=ckanext-geodatagov
 ckanext-googleanalyticsbasic @ git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@main
--e git+https://github.com/GSA/ckanext-harvest.git@datagov-py3#egg=ckanext-harvest
+-e git+https://github.com/ckan/ckanext-harvest.git#egg=ckanext-harvest
 -e git+https://github.com/gsa/ckanext-spatial.git@datagov#egg=ckanext-spatial
 
 

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -14,7 +14,7 @@ ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@c4e7319aff55e5315831b28e
 ckanext-envvars @ git+https://github.com/GSA/ckanext-envvars.git@33f7e190ab332244cb961a425e09af592d9b647b
 -e git+https://github.com/GSA/ckanext-geodatagov.git@af6378074fcbc2705e7e33960d5ddd2c8e46ed4c#egg=ckanext_geodatagov
 ckanext-googleanalyticsbasic @ git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@c6a425d5e14d658c0fa3661fdc4423162161c3f4
--e git+https://github.com/GSA/ckanext-harvest.git@925b0eefa10139bb7868639e8085a4f18ae05dff#egg=ckanext_harvest
+-e git+https://github.com/GSA/ckanext-harvest.git@9d5679f0461f5aac05b7f800e11b6a62afb7feeb#egg=ckanext_harvest
 -e git+https://github.com/gsa/ckanext-spatial.git@964c65284e8105bf6823457ee8053ecc978d591d#egg=ckanext_spatial
 ckantoolkit==0.0.3
 click==7.1.2


### PR DESCRIPTION
Recent custom fixes have been merged into upstream;
can get off of fork and custom management.

Related to https://github.com/GSA/datagov-deploy/issues/3480

Confirmed that there is no difference between previous fork and ckanext-harvest upstream:
![image](https://user-images.githubusercontent.com/26980513/138707450-2271e65e-3888-4bf7-ab5b-71cfd6f1f2a6.png)
