### PR TITLE
Feature/sysadmin service

### DIFF
--- a/.profile
+++ b/.profile
@@ -74,7 +74,7 @@ export CKANEXT__SAML2AUTH__CERT_FILE_PATH=${CONFIG_DIR}/saml2_certificate.pem
 
 export NEW_RELIC_LICENSE_KEY=$(vcap_get_service secrets .credentials.NEW_RELIC_LICENSE_KEY)
 # Get sysadmins list by a user-provided-service per environment
-export CKANEXT__SAML2AUTH__SYSADMINS_LIST=$(echo $VCAP_SERVICES | jq --raw-output "sysadmin-users" ".[][] | select(.name == \sysadmin-users) | CKANEXT__SAML2AUTH__SYSADMINS_LIST")
+export CKANEXT__SAML2AUTH__SYSADMINS_LIST=$(echo $VCAP_SERVICES | jq --raw-output ".[][] | select(.name == \"sysadmin-users\") | .credentials.CKANEXT__SAML2AUTH__SYSADMINS_LIST")
 
 # Write out any files and directories
 mkdir -p $CKAN_STORAGE_PATH

--- a/.profile
+++ b/.profile
@@ -73,6 +73,8 @@ export CKANEXT__SAML2AUTH__KEY_FILE_PATH=${CONFIG_DIR}/saml2_key.pem
 export CKANEXT__SAML2AUTH__CERT_FILE_PATH=${CONFIG_DIR}/saml2_certificate.pem
 
 export NEW_RELIC_LICENSE_KEY=$(vcap_get_service secrets .credentials.NEW_RELIC_LICENSE_KEY)
+# Get sysadmins list by a user-provided-service per environment
+export CKANEXT__SAML2AUTH__SYSADMINS_LIST=$(echo $VCAP_SERVICES | jq --raw-output "sysadmin-users" ".[][] | select(.name == \sysadmin-users) | CKANEXT__SAML2AUTH__SYSADMINS_LIST")
 
 # Write out any files and directories
 mkdir -p $CKAN_STORAGE_PATH

--- a/manifest.yml
+++ b/manifest.yml
@@ -14,6 +14,7 @@ applications:
       - ((app_name))-db
       - ((app_name))-redis
       - ((app_name))-secrets
+      - sysadmin-users
     routes: ((routes))
     processes:
     - type: web


### PR DESCRIPTION
Related to https://github.com/GSA/datagov-deploy/issues/3482

Requires a new service be created, `sysadmin-users`, that has the emails of all the users that should be sysadmins.
This will require a similar change on inventory, once login is setup appropriately.

The services have been created in staging and prod. Confirmed that develop deployment changed my ckan account from basic (no permissions, just login access successfully) to sysadmin (full access, can create org, etc).