### PR TITLE
Change processes to separate apps

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -75,6 +75,22 @@ jobs:
           space: development
           user: ${{secrets.CF_SERVICE_USER}}
           password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: deploy-gather
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: push catalog-gather --vars-file vars.development.yml
+          org: gsa-datagov
+          space: development
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: deploy-fetch
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: push catalog-fetch --vars-file vars.development.yml
+          org: gsa-datagov
+          space: development
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
       - name: smoke test
         run: |
           sleep 10

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,6 +147,22 @@ jobs:
           space: prod
           user: ${{secrets.CF_SERVICE_USER}}
           password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: deploy-gather
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: push catalog-gather --vars-file vars.production.yml
+          org: gsa-datagov
+          space: prod
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: deploy-fetch
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: push catalog-fetch --vars-file vars.production.yml
+          org: gsa-datagov
+          space: prod
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
       - name: smoke test
         run: |
           sleep 10

--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: restart web
+      - name: restart
         uses: usds/cloud-gov-cli@master
         with:
           command: restart catalog --strategy rolling

--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -13,10 +13,26 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: restart
+      - name: restart web
         uses: usds/cloud-gov-cli@master
         with:
           command: restart catalog --strategy rolling
+          org: gsa-datagov
+          space: staging
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: restart gather
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: restart catalog-gather
+          org: gsa-datagov
+          space: staging
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: restart fetch
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: restart catalog-fetch
           org: gsa-datagov
           space: staging
           user: ${{secrets.CF_SERVICE_USER}}
@@ -37,6 +53,22 @@ jobs:
         uses: usds/cloud-gov-cli@master
         with:
           command: restart catalog --strategy rolling
+          org: gsa-datagov
+          space: prod
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: restart gather
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: restart catalog-gather
+          org: gsa-datagov
+          space: prod
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: restart fetch
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: restart catalog-fetch
           org: gsa-datagov
           space: prod
           user: ${{secrets.CF_SERVICE_USER}}

--- a/manifest.yml
+++ b/manifest.yml
@@ -16,23 +16,55 @@ applications:
       - ((app_name))-secrets
       - sysadmin-users
     routes: ((routes))
-    processes:
-    - type: web
-      instances: ((web-instances))
-      command: ckan run --host "0.0.0.0" --port $PORT
-      health-check-type: http
-      health-check-http-endpoint: /dataset
-      health-check-invocation-timeout: 10
-    - type: harvest-gather
-      instances: ((gather-instances))
-      command: ckan harvester gather-consumer
-      health-check-type: process
-      timeout: 15
-    - type: harvest-fetch
-      instances: ((fetch-instances))
-      command: ckan harvester fetch-consumer
-      health-check-type: process
-      timeout: 15
+    health-check-type: http
+    health-check-http-endpoint: /dataset
+    health-check-invocation-timeout: 10
+    instances: ((web-instances))
+    command: ckan run --host "0.0.0.0" --port $PORT
+    env:
+      CKAN_SOLR_URL: http://((solr_route)):8983/solr/ckan
+      CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH: ((ckanext__saml2auth__idp_metadata__local_path))
+      CKANEXT__SAML2AUTH__ENTITY_ID: ((ckanext__saml2auth__entity_id))
+      SAML2_CERTIFICATE: ((saml2_certificate))
+      NEW_RELIC_APP_NAME: ((new_relic_app_name))
+      NEW_RELIC_HOST: gov-collector.newrelic.com
+      NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
+  - name: ((app_name))-gather
+    buildpacks:
+      - https://github.com/cloudfoundry/apt-buildpack
+      - python_buildpack
+    services:
+      - ((app_name))-db
+      - ((app_name))-redis
+      - ((app_name))-secrets
+      - sysadmin-users
+    routes: ((routes))
+    instances: ((gather-instances))
+    command: ckan harvester gather-consumer
+    health-check-type: process
+    timeout: 15
+    
+    env:
+      CKAN_SOLR_URL: http://((solr_route)):8983/solr/ckan
+      CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH: ((ckanext__saml2auth__idp_metadata__local_path))
+      CKANEXT__SAML2AUTH__ENTITY_ID: ((ckanext__saml2auth__entity_id))
+      SAML2_CERTIFICATE: ((saml2_certificate))
+      NEW_RELIC_APP_NAME: ((new_relic_app_name))
+      NEW_RELIC_HOST: gov-collector.newrelic.com
+      NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
+  - name: ((app_name))-fetch
+    buildpacks:
+      - https://github.com/cloudfoundry/apt-buildpack
+      - python_buildpack
+    services:
+      - ((app_name))-db
+      - ((app_name))-redis
+      - ((app_name))-secrets
+      - sysadmin-users
+    instances: ((fetch-instances))
+    command: ckan harvester fetch-consumer
+    health-check-type: process
+    timeout: 15
     env:
       CKAN_SOLR_URL: http://((solr_route)):8983/solr/ckan
       CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH: ((ckanext__saml2auth__idp_metadata__local_path))


### PR DESCRIPTION
Change processes to be separate apps, and manage accordingly.
Setup restarts and deployments for each.

Deployment changes worked in dev, see [here](https://github.com/GSA/catalog.data.gov/runs/4291290963?check_suite_focus=true).