### PR TITLE
Update rdflib to support new setuptools

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -74,7 +74,7 @@ xlrd>=1.0.0
 messytables>=0.15.2
 
 #ckanext-dcat
-rdflib==4.2.1
+rdflib==4.2.2
 # rdflib-jsonld==0.4.0 # ignoring as cannot build on cloud.gov
 geomet>=0.2.0
 future>=0.18.2

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -77,7 +77,7 @@ pytz==2016.7
 PyUtilib==5.7.1
 PyYAML==5.4
 PyZ3950 @ git+https://github.com/danizen/PyZ3950@6d44a4ab85c8bda3a7542c2c9efdfad46c830219
-rdflib==4.2.1
+rdflib==4.2.2
 redis==4.0.0
 repoze.lru==0.7
 repoze.who==2.3

--- a/vendor-requirements.sh
+++ b/vendor-requirements.sh
@@ -14,14 +14,15 @@ docker run --mount type=bind,source="$(pwd)",target=/home/vcap/app --tmpfs /home
 cd ~vcap/app
 
 # Install any packaged dependencies for our vendored packages
+# Install python3.7 because that's what the buildpak uses
 apt-get -y update
-apt-get -y install swig build-essential python-dev libssl-dev
+apt-get -y install swig build-essential python-dev libssl-dev python3.7
 
 echo "Past apt-get, downloading pip..."
 
 # Install PIP
 curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
-python3 /tmp/get-pip.py
+python3.7 /tmp/get-pip.py
 
 # As the VCAP user, cache .whls based on the frozen requirements for vendoring
 mkdir -p src vendor


### PR DESCRIPTION
This was triggered by `python-buildpak` supporting minimum `setuptools 59.8.0` which requires minimum `python3.7`.
```
Python Version   |  Setuptools Version  |  rdflib version  |  Working?
3.6.9            |  59.6.0              |  4.2.1           |  yes
3.7.0            |  60.0.0              |  4.2.1           |  no
3.7.0            |  60.0.0              |  4.2.2           |  yes
3.7.0            |  60.0.0              |  6.0.0           |  yes
```
- `setuptools v59.6.0`  is the last supported version for `python 3.6`
- `rdflib v6.0.0` is the latest supported major version.
- `ckanext-dcat` stills says that it relies on `rdflib v4.2.1`
- I tried to run the tests for `ckanext-dcat` with `python3.8` (that's what I have locally) and `rdflib6.0.0` and the tests fail with syntax issues with pylons...

Summary... we have to update the version of rdflib  for setuptools to be able to install it.