### PR TITLE
Download cypress results from github actions

### DIFF
--- a/.github/workflows/download-cypress.yml
+++ b/.github/workflows/download-cypress.yml
@@ -1,0 +1,21 @@
+
+name: Download Cypress Results
+on:
+  workflow_dispatch:
+
+jobs:
+  download:
+    name: 'Download'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: my-artifact
+        path: ./e2e/cypress/videos/
+
+    - name: Display structure of downloaded files
+      run: ls -R
+      working-directory: ./e2e/cypress/


### PR DESCRIPTION
Attempt to follow [Artifact Download Instructions](https://github.com/actions/download-artifact) to see the results of failed cypress tests on Github Actions.  This may need to be in the context of the action that uploaded the artifacts.  But based on the documentation, it doesn't seem like it has to be.

Note: artifacts are case-insensitive and will overwrite each other.  Our current cypress tests don't name each run, so there's probably only one set of artifacts available to download (which would be the most recent run).