### PR TITLE
Increase solr shards

### DIFF
--- a/ckan/setup/ckan_setup.sh
+++ b/ckan/setup/ckan_setup.sh
@@ -53,14 +53,14 @@ ckan config-tool $SRC_DIR/ckan/test-core.ini \
 # SOLR takes a while to boot up in zookeeper mode, make sure it's up before
 echo "Validating SOLR is up..."
 NEXT_WAIT_TIME=0
-until [ $NEXT_WAIT_TIME -eq 10 ] || curl --get --fail --quiet --location-trusted  --user $CKAN_SOLR_USER:$CKAN_SOLR_PASSWORD \
+until [ $NEXT_WAIT_TIME -eq 15 ] || curl --get --fail --quiet --location-trusted  --user $CKAN_SOLR_USER:$CKAN_SOLR_PASSWORD \
     $CKAN_SOLR_BASE_URL/solr/admin/collections \
     --data-urlencode action=list \
     --data-urlencode wt=json; do
     sleep $(( NEXT_WAIT_TIME++ ))
     echo "SOLR still not up, trying for the $NEXT_WAIT_TIME time"
 done
-[ $NEXT_WAIT_TIME -lt 10 ]
+[ $NEXT_WAIT_TIME -lt 15 ]
 
 # Add ckan core to solr
 /app/ckan/setup/migrate-solrcloud-schema.sh

--- a/ckan/setup/migrate-solrcloud-schema.sh
+++ b/ckan/setup/migrate-solrcloud-schema.sh
@@ -43,7 +43,7 @@ if ! (curl --get --fail --location-trusted  --user $CKAN_SOLR_USER:$CKAN_SOLR_PA
 
     echo "Creating solr collection..."
     curl --fail  --location-trusted --user $CKAN_SOLR_USER:$CKAN_SOLR_PASSWORD \
-        "$CKAN_SOLR_BASE_URL/solr/admin/collections?action=create&name=$COLLECTION_NAME&collection.configName=$COLLECTION_NAME&numShards=1" \
+        "$CKAN_SOLR_BASE_URL/solr/admin/collections?action=create&name=$COLLECTION_NAME&collection.configName=$COLLECTION_NAME&numShards=2&replicationFactor=2" \
         -X POST
 
     cd -

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,14 +27,16 @@ services:
     image: ghcr.io/gsa/catalog.data.gov.solr:8-curl
     environment:
       - ZK_HOST=zookeeper1:2181,zookeeper2:2182,zookeeper3:2183
-    ports:
-      - "8983:8983"
+    # ports:
+    #   - "8983:8983"
+    deploy:
+      replicas: 4
     depends_on:
       - zookeeper1
       - zookeeper2
       - zookeeper3
-    volumes:
-      - solr_data:/var/solr
+    # volumes:
+    #   - solr_data:/var/solr
 
   zookeeper1:
     image: zookeeper:3.7
@@ -97,7 +99,6 @@ services:
 volumes:
   ckan_storage:
   pg_data:
-  solr_data:
   zookeeperdata:
   zookeeperdatalog:
   zookeeperdata2:

--- a/solr/service-config.json
+++ b/solr/service-config.json
@@ -1,4 +1,5 @@
 {
     "solrImageRepo": "ghcr.io/gsa/catalog.data.gov.solr",
-    "solrImageTag": "8-curl"
+    "solrImageTag": "8-curl",
+    "replicas": 4
 }


### PR DESCRIPTION
Update solr service to have 2 replicas of 2 shards spread across 4 nodes,
- Node param: https://artifacthub.io/packages/helm/apache-solr/solr#running-solr
- Solr create collection params: https://solr.apache.org/guide/8_11/collection-management.html#create-parameters