### PR TITLE
Fix prod backend route

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -93,14 +93,6 @@ jobs:
           cf_space: development
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
-      - name: deploy proxy
-        uses: cloud-gov/cg-cli-tools@cli-v8
-        with:
-          command: cf push catalog-proxy --vars-file vars.development.yml --strategy rolling
-          cf_org: gsa-datagov
-          cf_space: development
-          cf_username: ${{secrets.CF_SERVICE_USER}}
-          cf_password: ${{secrets.CF_SERVICE_AUTH}}
       - name: deploy-gather
         uses: cloud-gov/cg-cli-tools@cli-v8
         with:

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -11,16 +11,19 @@ fetch-instances: 1
 new_relic_app_name: catalog (develop)
 new_relic_monitor_mode: false
 
-routes-external:
+routes-internal:
   - route: catalog-dev-datagov.app.cloud.gov
 
-routes-internal:
-  - route: catalog-dev-9a24aaa4-5023-4bd5-9d45-dec0258786ed.app.cloud.gov
-
-# Name of external server
-server-name: catalog-dev-datagov.app.cloud.gov
-# Name of internal ckan app
-server-uri: https://catalog-dev-9a24aaa4-5023-4bd5-9d45-dec0258786ed.app.cloud.gov
+# In case we ever want to have proxy in development, uncomment this
+# routes-external:
+#   - route: catalog-dev-datagov.app.cloud.gov
+# routes-internal:
+#   - route: catalog-dev-9a24aaa4-5023-4bd5-9d45-dec0258786ed.app.cloud.gov
+# 
+# # Name of external server
+# server-name: catalog-dev-datagov.app.cloud.gov
+# # Name of internal ckan app
+# server-uri: https://catalog-dev-9a24aaa4-5023-4bd5-9d45-dec0258786ed.app.cloud.gov
 
 saml2_certificate: |
   -----BEGIN CERTIFICATE-----

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -15,12 +15,12 @@ routes-external:
   - route: catalog-dev-datagov.app.cloud.gov
 
 routes-internal:
-  - route: catalog-dev-datagov.apps.internal
+  - route: catalog-dev-9a24aaa4-5023-4bd5-9d45-dec0258786ed.app.cloud.gov
 
 # Name of external server
 server-name: catalog-dev-datagov.app.cloud.gov
 # Name of internal ckan app
-server-uri: https://catalog-dev-datagov.apps.internal:61443
+server-uri: https://catalog-dev-9a24aaa4-5023-4bd5-9d45-dec0258786ed.app.cloud.gov
 
 saml2_certificate: |
   -----BEGIN CERTIFICATE-----

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -15,12 +15,12 @@ routes-external:
   - route: catalog-prod-datagov.app.cloud.gov
 
 routes-internal:
-  - route: catalog-prod-datagov.apps.internal
+  - route: catalog-prod-1041c49a-20d2-4f21-8bbc-e64bf739d8dd.app.cloud.gov
 
 # Name of external server
 server-name: catalog-prod-datagov.app.cloud.gov
 # Name of internal ckan app
-server-uri: https://catalog-prod-datagov.apps.internal:61443
+server-uri: https://catalog-prod-1041c49a-20d2-4f21-8bbc-e64bf739d8dd.app.cloud.gov
 
 saml2_certificate: |
   -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
We forgot to replicate the anonymous backend route on prod

Follow up for https://github.com/GSA/catalog.data.gov/pull/403