### PR TITLE
Update site url appropriately

### DIFF
--- a/.profile
+++ b/.profile
@@ -57,7 +57,6 @@ export APP_NAME=$(echo $VCAP_APPLICATION | jq -r '.application_name')
 if [[ $APP_NAME = "catalog-gather" ]] || [[ $APP_NAME = "catalog-fetch" ]]; then
   APP_NAME=catalog
 fi
-export APP_URL=$(echo $VCAP_APPLICATION | jq -r '.application_uris[0]')
 
 # Extract credentials from VCAP_SERVICES
 export REDIS_HOST=$(vcap_get_service redis .credentials.host)
@@ -67,7 +66,6 @@ export SAML2_PRIVATE_KEY=$(vcap_get_service secrets .credentials.SAML2_PRIVATE_K
 
 # Export settings for CKAN via ckanext-envvars
 export CKAN_REDIS_URL=rediss://:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT
-export CKAN_SITE_URL=https://$APP_URL
 export CKAN_SQLALCHEMY_URL=$(vcap_get_service db .credentials.uri)
 export CKAN_STORAGE_PATH=${SHARED_DIR}/files
 export CKAN___BEAKER__SESSION__SECRET=$(vcap_get_service secrets .credentials.CKAN___BEAKER__SESSION__SECRET)

--- a/manifest.yml
+++ b/manifest.yml
@@ -26,7 +26,7 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
-      CKAN_SITE_URL: ((ckan_site_url))
+      CKAN_SITE_URL: https://((routes-external))
 
   - name: ((app_name))-proxy
     buildpacks:
@@ -62,7 +62,7 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
-      CKAN_SITE_URL: ((ckan_site_url))
+      CKAN_SITE_URL: https://((routes-external))
 
   - name: ((app_name))-fetch
     buildpacks:
@@ -86,4 +86,4 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
-      CKAN_SITE_URL: ((ckan_site_url))
+      CKAN_SITE_URL: https://((routes-external))

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,7 +11,8 @@ applications:
       - ((app_name))-secrets
       - ((app_name))-solr
       - sysadmin-users
-    routes: ((routes-internal))
+    routes:
+      - route: ((routes-internal))
     health-check-type: http
     health-check-http-endpoint: /dataset
     health-check-invocation-timeout: 30
@@ -25,16 +26,20 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
+      CKAN_SITE_URL: ((ckan_site_url))
+
   - name: ((app_name))-proxy
     buildpacks:
       - https://github.com/cloudfoundry/nginx-buildpack
     path: ./proxy
     # TODO: tweak with load testing
     memory: 100M
-    routes: ((routes-external))
+    routes:
+      - route: ((routes-external))
     env:
       SERVER_NAME: ((server-name))
       SERVER_URI: ((server-uri))
+
   - name: ((app_name))-gather
     buildpacks:
       - https://github.com/cloudfoundry/apt-buildpack
@@ -50,7 +55,6 @@ applications:
     command: ckan harvester gather-consumer
     health-check-type: process
     timeout: 15
-    
     env:
       CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH: ((ckanext__saml2auth__idp_metadata__local_path))
       CKANEXT__SAML2AUTH__ENTITY_ID: ((ckanext__saml2auth__entity_id))
@@ -58,6 +62,8 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
+      CKAN_SITE_URL: ((ckan_site_url))
+
   - name: ((app_name))-fetch
     buildpacks:
       - https://github.com/cloudfoundry/apt-buildpack
@@ -80,3 +86,4 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
+      CKAN_SITE_URL: ((ckan_site_url))

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -11,8 +11,10 @@ fetch-instances: 1
 new_relic_app_name: catalog (develop)
 new_relic_monitor_mode: false
 
-routes-internal:
-  - route: catalog-dev-datagov.app.cloud.gov
+routes-internal: catalog-dev-datagov.app.cloud.gov
+routes-external: catalog-dev-datagov.app.cloud.gov
+
+ckan_site_url: https://catalog-dev-datagov.app.cloud.gov
 
 # In case we ever want to have proxy in development, uncomment this
 # routes-external:

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -14,8 +14,6 @@ new_relic_monitor_mode: false
 routes-internal: catalog-dev-datagov.app.cloud.gov
 routes-external: catalog-dev-datagov.app.cloud.gov
 
-ckan_site_url: https://catalog-dev-datagov.app.cloud.gov
-
 # In case we ever want to have proxy in development, uncomment this
 # routes-external:
 #   - route: catalog-dev-datagov.app.cloud.gov

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -11,11 +11,10 @@ fetch-instances: 1
 new_relic_app_name: catalog
 new_relic_monitor_mode: true
 
-routes-external:
-  - route: catalog-prod-datagov.app.cloud.gov
+routes-external: catalog-prod-datagov.app.cloud.gov
+routes-internal: catalog-prod-1041c49a-20d2-4f21-8bbc-e64bf739d8dd.app.cloud.gov
 
-routes-internal:
-  - route: catalog-prod-1041c49a-20d2-4f21-8bbc-e64bf739d8dd.app.cloud.gov
+ckan_site_url: https://catalog-prod-datagov.app.cloud.gov
 
 # Name of external server
 server-name: catalog-prod-datagov.app.cloud.gov

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -14,8 +14,6 @@ new_relic_monitor_mode: true
 routes-external: catalog-prod-datagov.app.cloud.gov
 routes-internal: catalog-prod-1041c49a-20d2-4f21-8bbc-e64bf739d8dd.app.cloud.gov
 
-ckan_site_url: https://catalog-prod-datagov.app.cloud.gov
-
 # Name of external server
 server-name: catalog-prod-datagov.app.cloud.gov
 # Name of internal ckan app

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -14,8 +14,6 @@ new_relic_monitor_mode: true
 routes-external: catalog-stage-datagov.app.cloud.gov
 routes-internal: catalog-stage-cdd4197f-65a7-450e-a34c-f24c9042f9ef.app.cloud.gov
 
-ckan_site_url: https://catalog-stage-datagov.app.cloud.gov
-
 # Name of external server
 server-name: catalog-stage-datagov.app.cloud.gov
 # Name of internal ckan app

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -11,11 +11,10 @@ fetch-instances: 1
 new_relic_app_name: catalog (staging)
 new_relic_monitor_mode: true
 
-routes-external:
-  - route: catalog-stage-datagov.app.cloud.gov
+routes-external: catalog-stage-datagov.app.cloud.gov
+routes-internal: catalog-stage-cdd4197f-65a7-450e-a34c-f24c9042f9ef.app.cloud.gov
 
-routes-internal:
-  - route: catalog-stage-cdd4197f-65a7-450e-a34c-f24c9042f9ef.app.cloud.gov
+ckan_site_url: https://catalog-stage-datagov.app.cloud.gov
 
 # Name of external server
 server-name: catalog-stage-datagov.app.cloud.gov


### PR DESCRIPTION
CKAN needs the site url to be set to the correct domain in order to serve responses properly. This is more complicated, and we need to be more explicit now that there is an nginx proxy.