### PR TITLE
Use full path for local files

### DIFF
--- a/.profile
+++ b/.profile
@@ -63,6 +63,7 @@ export REDIS_HOST=$(vcap_get_service redis .credentials.host)
 export REDIS_PASSWORD=$(vcap_get_service redis .credentials.password)
 export REDIS_PORT=$(vcap_get_service redis .credentials.port)
 export SAML2_PRIVATE_KEY=$(vcap_get_service secrets .credentials.SAML2_PRIVATE_KEY)
+export CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH="${HOME}/${CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH}"
 
 # Export settings for CKAN via ckanext-envvars
 export CKAN_REDIS_URL=rediss://:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT


### PR DESCRIPTION
Related to https://github.com/GSA/datagov-deploy/issues/3641

Auth files did not have the full path, [inventory already does this](https://github.com/GSA/inventory-app/blob/main/.profile#L77). Tested and confirmed on staging.
![image](https://user-images.githubusercontent.com/26980513/152887196-c82a213c-0b56-4504-ac52-85dfab35fc3e.png)
