### PR TITLE
switch from identitysandbox.gov to login.gov

### DIFF
--- a/ckan/setup/login.production.idp.xml
+++ b/ckan/setup/login.production.idp.xml
@@ -1,0 +1,66 @@
+<EntityDescriptor ID="_39724e00-866e-013a-ef5c-028095ede6e9" xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://secure.login.gov/api/saml">
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+      </ds:CanonicalizationMethod>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256">
+      </ds:SignatureMethod>
+      <ds:Reference URI="#_39724e00-866e-013a-ef5c-028095ede6e9">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature">
+          </ds:Transform>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256">
+        </ds:DigestMethod>
+        <ds:DigestValue>WQXMEzWTg7LwnEekG5Vq2QmakDVEadh4ai4DgmS5QiM=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>XwQv/5/uw34HwgFXkmHZIrzLAgwdKwAwuBsOYwUyHrnGo2QMLxrFQ1n/9Y0LR3kBCLxflPvv+M2L4552A68GUhcqjdqGCFr5OIFCpzPC9LRplWUAFhbPBiuWEz6PvSMUa3ZUQngTM4Ia/xl85iASP2g+LZVSTgixlNCbyJWz1FHDxoBSblcRS4PaWLjAc9WZAausJnL/q5hWYvlG0N0EVNDBy1JinY+FLNVp45iNKTf9fo8LlBRMJA54+bDh8frkGtCdIBpHK0JFd2i+cqNj+1ED0KaHN6ZuJ1uzHZUqju2wrp7K8Bq/DCn29A+93zyTp2SxNjjlrJwk5VCIVK2E6I/KrMS9MLEbSzVKM9R7GdlKFeQ9198gxaWYAzL5IH5e6sZ80ll6M9K5DfKH+OKDVhEjxw1sGhPTKbDif4noUk/EcaKRTxJZbT7bIOqSBvpSs7AZEYPsznou14i3tAH+rvwvujgLTgfmkU/ZuAxjzBrItTIBCcfd0oY/MMFYr4dZtmr9v6kRnf+UV6w1quOVAGEayvSM8F4oTLc27u4QwGmpZwvwIJ3mgaJr8Uu4gYQ7T6qMLVHuyR82JOA/8SVmbjlxzevjaALu6oDD6md6OP8LKfEk/GpJdzPCwKRh8IJmaV9IUBoRlM/iZmPcnp1VxFkx2VYr0HyKi+umLu6rzwc=</ds:SignatureValue>
+    <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <ds:X509Data>
+        <ds:X509Certificate>MIIGCDCCA/CgAwIBAgIRAPLNlmd+55a5ee4p1DpaidIwDQYJKoZIhvcNAQELBQAwXzESMBAGA1UEAwwJbG9naW4uZ292MQwwCgYDVQQLDANUVFMxDDAKBgNVBAoMA0dTQTETMBEGA1UEBwwKV2FzaGluZ3RvbjELMAkGA1UECAwCREMxCzAJBgNVBAYTAlVTMB4XDTIyMDEwMTAwMDAwMFoXDTIzMDQwMTAwMDAwMFowXzESMBAGA1UEAwwJbG9naW4uZ292MQwwCgYDVQQLDANUVFMxDDAKBgNVBAoMA0dTQTETMBEGA1UEBwwKV2FzaGluZ3RvbjELMAkGA1UECAwCREMxCzAJBgNVBAYTAlVTMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA07t+UBYf7DnyXz3whew3nkLUQcqotlAZWaY5maF5qozKSerE0o3G1ZeM7BAyTz++sUcBkKo3wbj2oc0C4muR80s7Tu2JZMVdAasi8un+lsVwaVURL2HfTDRvBE6IUqo9NmxDwcKsdowSYiHdDxz5T7nFR//CvbaoRj88XU0SpqZ0gsVZd4reP8U0yoOKo6rssXABXMVNSfnPPqFBqAiad3pUVNsHRwpQo8fg9GP5y9+pmEIbpiDga4GipXtMIyfYA/qkgWgpb2Nv5UkmMYzX9nuTileat0tP/fuNfgWwMdTWbqJmHzNQ2Pwz9Tk6ja8jvAVx/ff2LIbgP7QvVQLvvuC2SlmsXRCVY11clYjLL95tinT1gYb2xrqTv/vULtdRijtu4QgJiZPcdGg6K7C4NBgy7Pw/yAML4SHvpmMvWYASND6mZKbjtLrq9TdQdCoRLltu0pR5UrpZKiC3VDI2mNA8bUuyDOx5807u+4oYfCP9boDz6dfTZIdxmsarBxZCEN08nRAeXCsZJ66CGTW1Y2ggSGg9PFY+JD6iJ3pDwwJML0cxTslcDAOR3CbpP+g2v5jGm/xM/ZsAzm0fg9c+o+RV5RwzukQhjTtc8mGH3D5FXGVD+BMFgryPO02n85zooHm1R3zHaGfkTw2Wp9DSpUJf5OjEiRw0/tNmQkU3f3MCAwEAAaOBvjCBuzAdBgNVHQ4EFgQUvtJlH2rQp5rmhkphYdk9sKAXIwMwgZkGA1UdIwSBkTCBjoAUvtJlH2rQp5rmhkphYdk9sKAXIwOhY6RhMF8xEjAQBgNVBAMMCWxvZ2luLmdvdjEMMAoGA1UECwwDVFRTMQwwCgYDVQQKDANHU0ExEzARBgNVBAcMCldhc2hpbmd0b24xCzAJBgNVBAgMAkRDMQswCQYDVQQGEwJVU4IRAPLNlmd+55a5ee4p1DpaidIwDQYJKoZIhvcNAQELBQADggIBAMxDIc79/9t7UjxcyvzzD3pFyj0KfJEatWUYBDcroEEijV8ONkOT79orVW0VH16w9sPCAftY/o3ZBAZUaGIHidVDZAB8a6DfsJkcoqRUgjbrQ6bECSeRaYTBLk7Fh4likYjftunFxHgdnIhUkiv0tAWeEBJZpowWQbIfTX1say4+DwvbLdySFlGKePD+Hsrk2Fz610nGwb9PKN/Lm3LoD+MfoAtVHTAAs1Fndv4F83v5E9A3ANn8ggxF67BQP/0Dx55JsMUm6PlvI/9Hvt1ESa4EKmQIdtVgWf/9qZBmN9uypdSb7ngaJ6GG2JNn9f6sTbMn8dm9dlv7IZC3fOY7c17Dv1fA9B8Nre0zIrT/uoMSQjYak/ddPmcGaLxws/yVc1GntvACUD4pIlGtUuXbQ7U7iDo7qmYIBmb9Mp1mhcBG2xQE2/jOVBvvjK2/VThQ1nNTIg20B1AOUWpdNFoxEM5YwaduNc43afe5d4+nZz4pk5hyC0dJCmxLpV/j4VyQZr5hXfZ/u32wHzrC5hzhc//9HTL9TPbbzXO5/Fpg4r3UG5zyMsyPmoPDHsJKNNxKYRgxunSUkxkpZdMKmlm1avUHBK67dC5eWVKhhbUndZwaCR2w2Mb2fEVxpborjbAlIdpa1V1hRiNewmr/VUkOVsGepJZH5X4cjbWuoFci6FG6</ds:X509Certificate>
+      </ds:X509Data>
+    </KeyInfo>
+  </ds:Signature>
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIGCDCCA/CgAwIBAgIRAPLNlmd+55a5ee4p1DpaidIwDQYJKoZIhvcNAQELBQAwXzESMBAGA1UEAwwJbG9naW4uZ292MQwwCgYDVQQLDANUVFMxDDAKBgNVBAoMA0dTQTETMBEGA1UEBwwKV2FzaGluZ3RvbjELMAkGA1UECAwCREMxCzAJBgNVBAYTAlVTMB4XDTIyMDEwMTAwMDAwMFoXDTIzMDQwMTAwMDAwMFowXzESMBAGA1UEAwwJbG9naW4uZ292MQwwCgYDVQQLDANUVFMxDDAKBgNVBAoMA0dTQTETMBEGA1UEBwwKV2FzaGluZ3RvbjELMAkGA1UECAwCREMxCzAJBgNVBAYTAlVTMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA07t+UBYf7DnyXz3whew3nkLUQcqotlAZWaY5maF5qozKSerE0o3G1ZeM7BAyTz++sUcBkKo3wbj2oc0C4muR80s7Tu2JZMVdAasi8un+lsVwaVURL2HfTDRvBE6IUqo9NmxDwcKsdowSYiHdDxz5T7nFR//CvbaoRj88XU0SpqZ0gsVZd4reP8U0yoOKo6rssXABXMVNSfnPPqFBqAiad3pUVNsHRwpQo8fg9GP5y9+pmEIbpiDga4GipXtMIyfYA/qkgWgpb2Nv5UkmMYzX9nuTileat0tP/fuNfgWwMdTWbqJmHzNQ2Pwz9Tk6ja8jvAVx/ff2LIbgP7QvVQLvvuC2SlmsXRCVY11clYjLL95tinT1gYb2xrqTv/vULtdRijtu4QgJiZPcdGg6K7C4NBgy7Pw/yAML4SHvpmMvWYASND6mZKbjtLrq9TdQdCoRLltu0pR5UrpZKiC3VDI2mNA8bUuyDOx5807u+4oYfCP9boDz6dfTZIdxmsarBxZCEN08nRAeXCsZJ66CGTW1Y2ggSGg9PFY+JD6iJ3pDwwJML0cxTslcDAOR3CbpP+g2v5jGm/xM/ZsAzm0fg9c+o+RV5RwzukQhjTtc8mGH3D5FXGVD+BMFgryPO02n85zooHm1R3zHaGfkTw2Wp9DSpUJf5OjEiRw0/tNmQkU3f3MCAwEAAaOBvjCBuzAdBgNVHQ4EFgQUvtJlH2rQp5rmhkphYdk9sKAXIwMwgZkGA1UdIwSBkTCBjoAUvtJlH2rQp5rmhkphYdk9sKAXIwOhY6RhMF8xEjAQBgNVBAMMCWxvZ2luLmdvdjEMMAoGA1UECwwDVFRTMQwwCgYDVQQKDANHU0ExEzARBgNVBAcMCldhc2hpbmd0b24xCzAJBgNVBAgMAkRDMQswCQYDVQQGEwJVU4IRAPLNlmd+55a5ee4p1DpaidIwDQYJKoZIhvcNAQELBQADggIBAMxDIc79/9t7UjxcyvzzD3pFyj0KfJEatWUYBDcroEEijV8ONkOT79orVW0VH16w9sPCAftY/o3ZBAZUaGIHidVDZAB8a6DfsJkcoqRUgjbrQ6bECSeRaYTBLk7Fh4likYjftunFxHgdnIhUkiv0tAWeEBJZpowWQbIfTX1say4+DwvbLdySFlGKePD+Hsrk2Fz610nGwb9PKN/Lm3LoD+MfoAtVHTAAs1Fndv4F83v5E9A3ANn8ggxF67BQP/0Dx55JsMUm6PlvI/9Hvt1ESa4EKmQIdtVgWf/9qZBmN9uypdSb7ngaJ6GG2JNn9f6sTbMn8dm9dlv7IZC3fOY7c17Dv1fA9B8Nre0zIrT/uoMSQjYak/ddPmcGaLxws/yVc1GntvACUD4pIlGtUuXbQ7U7iDo7qmYIBmb9Mp1mhcBG2xQE2/jOVBvvjK2/VThQ1nNTIg20B1AOUWpdNFoxEM5YwaduNc43afe5d4+nZz4pk5hyC0dJCmxLpV/j4VyQZr5hXfZ/u32wHzrC5hzhc//9HTL9TPbbzXO5/Fpg4r3UG5zyMsyPmoPDHsJKNNxKYRgxunSUkxkpZdMKmlm1avUHBK67dC5eWVKhhbUndZwaCR2w2Mb2fEVxpborjbAlIdpa1V1hRiNewmr/VUkOVsGepJZH5X4cjbWuoFci6FG6</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://secure.login.gov/api/saml/auth2022"/>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://secure.login.gov/api/saml/auth2022"/>
+  </IDPSSODescriptor>
+  <AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIGCDCCA/CgAwIBAgIRAPLNlmd+55a5ee4p1DpaidIwDQYJKoZIhvcNAQELBQAwXzESMBAGA1UEAwwJbG9naW4uZ292MQwwCgYDVQQLDANUVFMxDDAKBgNVBAoMA0dTQTETMBEGA1UEBwwKV2FzaGluZ3RvbjELMAkGA1UECAwCREMxCzAJBgNVBAYTAlVTMB4XDTIyMDEwMTAwMDAwMFoXDTIzMDQwMTAwMDAwMFowXzESMBAGA1UEAwwJbG9naW4uZ292MQwwCgYDVQQLDANUVFMxDDAKBgNVBAoMA0dTQTETMBEGA1UEBwwKV2FzaGluZ3RvbjELMAkGA1UECAwCREMxCzAJBgNVBAYTAlVTMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA07t+UBYf7DnyXz3whew3nkLUQcqotlAZWaY5maF5qozKSerE0o3G1ZeM7BAyTz++sUcBkKo3wbj2oc0C4muR80s7Tu2JZMVdAasi8un+lsVwaVURL2HfTDRvBE6IUqo9NmxDwcKsdowSYiHdDxz5T7nFR//CvbaoRj88XU0SpqZ0gsVZd4reP8U0yoOKo6rssXABXMVNSfnPPqFBqAiad3pUVNsHRwpQo8fg9GP5y9+pmEIbpiDga4GipXtMIyfYA/qkgWgpb2Nv5UkmMYzX9nuTileat0tP/fuNfgWwMdTWbqJmHzNQ2Pwz9Tk6ja8jvAVx/ff2LIbgP7QvVQLvvuC2SlmsXRCVY11clYjLL95tinT1gYb2xrqTv/vULtdRijtu4QgJiZPcdGg6K7C4NBgy7Pw/yAML4SHvpmMvWYASND6mZKbjtLrq9TdQdCoRLltu0pR5UrpZKiC3VDI2mNA8bUuyDOx5807u+4oYfCP9boDz6dfTZIdxmsarBxZCEN08nRAeXCsZJ66CGTW1Y2ggSGg9PFY+JD6iJ3pDwwJML0cxTslcDAOR3CbpP+g2v5jGm/xM/ZsAzm0fg9c+o+RV5RwzukQhjTtc8mGH3D5FXGVD+BMFgryPO02n85zooHm1R3zHaGfkTw2Wp9DSpUJf5OjEiRw0/tNmQkU3f3MCAwEAAaOBvjCBuzAdBgNVHQ4EFgQUvtJlH2rQp5rmhkphYdk9sKAXIwMwgZkGA1UdIwSBkTCBjoAUvtJlH2rQp5rmhkphYdk9sKAXIwOhY6RhMF8xEjAQBgNVBAMMCWxvZ2luLmdvdjEMMAoGA1UECwwDVFRTMQwwCgYDVQQKDANHU0ExEzARBgNVBAcMCldhc2hpbmd0b24xCzAJBgNVBAgMAkRDMQswCQYDVQQGEwJVU4IRAPLNlmd+55a5ee4p1DpaidIwDQYJKoZIhvcNAQELBQADggIBAMxDIc79/9t7UjxcyvzzD3pFyj0KfJEatWUYBDcroEEijV8ONkOT79orVW0VH16w9sPCAftY/o3ZBAZUaGIHidVDZAB8a6DfsJkcoqRUgjbrQ6bECSeRaYTBLk7Fh4likYjftunFxHgdnIhUkiv0tAWeEBJZpowWQbIfTX1say4+DwvbLdySFlGKePD+Hsrk2Fz610nGwb9PKN/Lm3LoD+MfoAtVHTAAs1Fndv4F83v5E9A3ANn8ggxF67BQP/0Dx55JsMUm6PlvI/9Hvt1ESa4EKmQIdtVgWf/9qZBmN9uypdSb7ngaJ6GG2JNn9f6sTbMn8dm9dlv7IZC3fOY7c17Dv1fA9B8Nre0zIrT/uoMSQjYak/ddPmcGaLxws/yVc1GntvACUD4pIlGtUuXbQ7U7iDo7qmYIBmb9Mp1mhcBG2xQE2/jOVBvvjK2/VThQ1nNTIg20B1AOUWpdNFoxEM5YwaduNc43afe5d4+nZz4pk5hyC0dJCmxLpV/j4VyQZr5hXfZ/u32wHzrC5hzhc//9HTL9TPbbzXO5/Fpg4r3UG5zyMsyPmoPDHsJKNNxKYRgxunSUkxkpZdMKmlm1avUHBK67dC5eWVKhhbUndZwaCR2w2Mb2fEVxpborjbAlIdpa1V1hRiNewmr/VUkOVsGepJZH5X4cjbWuoFci6FG6</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <Organization>
+      <OrganizationName xml:lang="en">login.gov</OrganizationName>
+      <OrganizationDisplayName xml:lang="en">login.gov</OrganizationDisplayName>
+      <OrganizationURL xml:lang="en">https://login.gov</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="technical">
+    </ContactPerson>
+    <AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://secure.login.gov/api/saml/attributes"/>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+  </AttributeAuthorityDescriptor>
+  <Organization>
+    <OrganizationName xml:lang="en">login.gov</OrganizationName>
+    <OrganizationDisplayName xml:lang="en">login.gov</OrganizationDisplayName>
+    <OrganizationURL xml:lang="en">https://login.gov</OrganizationURL>
+  </Organization>
+  <ContactPerson contactType="technical">
+  </ContactPerson>
+</EntityDescriptor>

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -2,7 +2,7 @@
 app_name: catalog
 
 ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-production-catalog
-ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.production.idp.xml
+ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.sandbox.idp.xml
 
 web-instances: 5
 gather-instances: 1

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -1,8 +1,8 @@
 # This is the name to use for the staging catalog app in Cloud Foundry
 app_name: catalog
 
-ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-prod-catalog
-ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.sandbox.idp.xml
+ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-production-catalog
+ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.production.idp.xml
 
 web-instances: 5
 gather-instances: 1
@@ -17,38 +17,5 @@ routes-internal: catalog-prod-datagov.apps.internal
 
 saml2_certificate: |
   -----BEGIN CERTIFICATE-----
-  MIIGWTCCBEECFAlhrXpPhQHFG+zVm9pWt/C4gyZqMA0GCSqGSIb3DQEBCwUAMIHo
-  MQswCQYDVQQGEwJVUzEdMBsGA1UECAwURGlzdHJpY3Qgb2YgQ29sdW1iaWExEzAR
-  BgNVBAcMCldhc2hpbmd0b24xKDAmBgNVBAoMH0dlbmVyYWwgU2VydmljZXMgQWRt
-  aW5pc3RyYXRpb24xKjAoBgNVBAsMIVRlY2hub2xvZ3kgVHJhbnNmb3JtYXRpb24g
-  U2VydmljZTEiMCAGCSqGSIb3DQEJARYTZGF0YWdvdmhlbHBAZ3NhLmdvdjErMCkG
-  A1UEAwwiY2F0YWxvZy1wcm9kLWRhdGFnb3YuYXBwLmNsb3VkLmdvdjAeFw0yMjAz
-  MTYxNTE0NDlaFw0yNDAzMTUxNTE0NDlaMIHoMQswCQYDVQQGEwJVUzEdMBsGA1UE
-  CAwURGlzdHJpY3Qgb2YgQ29sdW1iaWExEzARBgNVBAcMCldhc2hpbmd0b24xKDAm
-  BgNVBAoMH0dlbmVyYWwgU2VydmljZXMgQWRtaW5pc3RyYXRpb24xKjAoBgNVBAsM
-  IVRlY2hub2xvZ3kgVHJhbnNmb3JtYXRpb24gU2VydmljZTEiMCAGCSqGSIb3DQEJ
-  ARYTZGF0YWdvdmhlbHBAZ3NhLmdvdjErMCkGA1UEAwwiY2F0YWxvZy1wcm9kLWRh
-  dGFnb3YuYXBwLmNsb3VkLmdvdjCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC
-  ggIBANoZG7PloMgSNwykuxC17vZte+SE8blDX9ValyNc5Y6vNmUqi895pmsbTXW/
-  MLA1QBrr8zIE1BJRijP2rMLMp/cEmEe0DoV+H38y55CK5ZmjwGBrmI1OGXYo3z40
-  oMmkIAO383zZOpXIZ8XOtEtrMH9F8zsSIErUCyV3F13JlWD3phtyOBHa9VpUPRSd
-  V8HsCc7l+twlSHhbGIGZjYTZgEkMsD/+4F/7ck58aquM7Rk1dOK1JKdGWaCCn+1B
-  XnFgBoZ5Ej2E1yMCYth3CHzoVArYRcGwkYnX5PyYpWUPyTX5zcDOFpv5RxEncDXB
-  62d14qWg+ngDd3zbEcHVQOUIvka2bE3hsrg5VWnM7MQtRJeqOMshjTL5qgaMBv/S
-  P+qZ4hW5RXIWeKIDakTNWJSqVjcX5aCllZmCh9gLjUQDn8RmIKXa+rTuuK2Ar6wq
-  TnZ+FnMzYeIkqcfJwIYcyy6QWGSq7isQd7C/zElYGY8BU61FTAr7SJOQHT4JeEg4
-  qsDbwvhb1Wz6TjyBE+FZj1zO1yZKZUZ8VEZKO7CmZuVtKzrctKTP0XkfXGcxttX0
-  00dDWdJKf2N0IifLd6GaQ8HFG19N7nVGINqNGqBRYPLu81LVa4tDmto/Us7atPyF
-  J1Kjw5MrCqfTyqniFzSgKTHDZWgdMKxsALmnnP3/ttFet1qZAgMBAAEwDQYJKoZI
-  hvcNAQELBQADggIBAIq5dBBEzpkNte/CtzIbwk6NA/9Y3fS/Q7fh+0eOVD9yDprr
-  qIh6IoOKoQlfnDxrzKdY1ZxbksiT80fEw1GO/jxOmECQse71QWTeTmCsYQgYT6WI
-  RM3g9LlVKotlZvE9sCU/cs027084TXHZtWJTBnLGQ8yuKSGLR2mrL4wotcunhzqV
-  yQOdvfHHoThdnjAo4wVNxQfdE3JkgjvNELOrNDyJ4RaMmrg2JhAQfSOBgLR01mSf
-  EbPti+IhbuFmd4eFwTykKutXKIcoAToMTTo8h2wr/pEc9ESNWLkDibP6KiH4lsB0
-  SVh5uGypt1v5z4dHwF2PqlFgrHOAQCaR3SBXy5hCpfZzpFMFs7v0FpYCVWme5t6n
-  8Zl4+Qcogjk7p6arh+4b6fC8VLFgVa+zRwkzGHJAic5HdJ9OIYO8Hc84WW7ACDs2
-  d0A76OBvBPkQ0K3DAmtvseSNCvND2GXum2d+wyoPq/pUOgYJZ0/SGiRCrxBEOXg2
-  yHFry5XIwu0szZ7csvdYUXWMWG1R7HHEt76Se7j3rKoiVIVUxfULY2TEo8jvfbUp
-  ZpUmOO7SkUiBZe3EAlwkACTjbFxrCqGgDLsvxSEDJkLlCK2fOUHFRo3l4OcAUd4/
-  60FuWkQnVjpkvSsp8xHdb9huBvPqK+fV4i9O7v1z96Z1LSGLiYsRD2PKpTNz
+  placeholder
   -----END CERTIFICATE-----


### PR DESCRIPTION
Get SAML ready for cutover https://github.com/GSA/data.gov/issues/2788.

`saml2_certificate` seems to be ok to have placeholder value. This way we don't have to update it on future SP cert changes.
https://github.com/keitaroinc/ckanext-saml2auth/issues/67

1. This PR should be merged after catalog on cloud.gov becomes production.
2. Merging this PR will make catalog app talking to the mirrored login app on identitysandbox.
3. After verifying everything works as expected, we can submit a request to login.gov to Promote the login app from identitysandbox.gov to login.gov. It might take two weeks.
4. After login.gov fulfill the request, we can revert the last commit [b2f1b0d](https://github.com/GSA/catalog.data.gov/pull/436/commits/b2f1b0d1962ff396d9a0701715fe46b340294de9) and submit another PR to let catalog app take to login.gov
