### PR TITLE
... More Solr improvements

### DIFF
--- a/ckan/setup/solr/solrconfig.xml
+++ b/ckan/setup/solr/solrconfig.xml
@@ -309,7 +309,7 @@
          have some sort of hard autoCommit to limit the log size.
       -->
     <autoCommit>
-      <maxTime>${solr.autoCommit.maxTime:15000}</maxTime>
+      <maxTime>5000</maxTime>
       <openSearcher>false</openSearcher>
     </autoCommit>
 
@@ -320,7 +320,7 @@
       -->
 
     <autoSoftCommit>
-      <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
+      <maxTime>4000</maxTime>
     </autoSoftCommit>
 
     <!-- Update Related Event Listeners

--- a/solr/service-config.json
+++ b/solr/service-config.json
@@ -1,9 +1,9 @@
 {
     "solrImageRepo": "ghcr.io/gsa/catalog.data.gov.solr",
     "solrImageTag": "8-curl",
-    "replicas": 6,
-    "solrJavaMem": "-Xms7g -Xmx10g",
-    "solrMem": "14G",
-    "solrCpu": "3250m",
+    "replicas": 3,
+    "solrJavaMem": "-Xms30g -Xmx32g",
+    "solrMem": "34G",
+    "solrCpu": "17000m",
     "restartCron": "0 0 1 1 5"
 }

--- a/solr/service-config.json
+++ b/solr/service-config.json
@@ -4,5 +4,6 @@
     "replicas": 6,
     "solrJavaMem": "-Xms7g -Xmx10g",
     "solrMem": "14G",
-    "solrCpu": "3250m"
+    "solrCpu": "3250m",
+    "restartCron": "0 0 1 1 5"
 }


### PR DESCRIPTION
These changes cover our most recent, most successful test case for SolrCloud which implements the following changes,
- Zookeeper timeout options
  - Theory: this is the timeout between Solr and Zookeeper, if a Solr node times out with ZK, it gets out of sync and ZK can't communicate with it too well after that.
  - Action: Increase from 30,000 to 600,000. (Borrowed from the other team, no real derivation).
  - https://github.com/GSA/datagov-brokerpak-solr/pull/35
  - https://github.com/GSA/datagov-ssb/pull/138
- Solr Java Memory/Garbage Collection tuning
  - Theory: If there is a very expensive operation happening in Solr that causes it's memory to spike/crash alongside with garbage collection cleanup, Solr goes down and if CKAN keeps trying to do that with all of the nodes and then there's no leader because of this, it causes the collection to crash
  - Action: Increase Memory from 14GB to 32GB (Note: I didn't do anything with changing the type of garbage collection because it seems like the most optimal GC is implemented already)
  - Implemented in this PR
- Latency within AWS Availability Zones that causes sync issues between Solr/Zookeeper
  - Theory: Solr and ZK require a very very low latency connection to stay in sync and for ZK to do proper node management.  The guidance is to not run ZK across multiple  AZs.
  - Action: Deploy managed node group to just one availability zone
  - https://github.com/GSA/datagov-brokerpak-eks/pull/93
- Solr Performance Specs for our Larger Document Sizes
  - Theory: Based on [this guidance](https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Text/3.9/tanzu-greenplum-text/GUID-topics-performance.html#indexing-large-numbers-of-documents), there's different values for autoCommit and autoSoftCommit based on Larger numbers of small documents vs. Very Large Documents.
  - Action: I decreased this to help keep Java Memory utilization low for our larger documents.
  - Implemented in this PR
- Disable Solr Restarts 
  - Theory: Performing a Solr restart while index writes are occurring causes problems when the nodes start coming back up again.  Read queries are fine to be occurring during restarts.  It's just if index writes aren't coordinated with ZK properly during leader transitions or transaction logging, it causes the collection to become unresponsive.
  - Action: "Disable" it by setting the next restart to be a very long time in the future (Jan 1st, 2027).
  - Implemented in this PR
  - Despite the following documentation, Solr does not handle restart recoveries for our data well,
    - https://solr.apache.org/guide/8_11/solrcloud-recoveries-and-write-tolerance.html#write-side-fault-tolerance
    - https://apache.github.io/solr-operator/docs/solr-cloud/solr-cloud-crd.html#update-strategy
    - https://apache.github.io/solr-operator/docs/solr-cloud/managed-updates.html

Things that we should do (but are not covered in this PR):
- Solr Performance with NewRelic
  - We've talked about this before, but if we really want to inspect Solr, we'll probably have to do the work to get this set up.