### PR TITLE
Don't overwrite existing security.json file

### DIFF
--- a/solr/solr_setup.sh
+++ b/solr/solr_setup.sh
@@ -2,8 +2,14 @@
 
 mkdir -p /tmp/ckan_config
 
+SECURITY_FILE=/var/solr/data/security.json
+if [ -f "$SECURITY_FILE" ]; then
+  echo "Solr ckan and authentication are set up already :)"
+  exit 0;
+fi
+
 # add solr authentication
-cat <<SOLRAUTH > /var/solr/data/security.json
+cat <<SOLRAUTH > $SECURITY_FILE
 {
 "authentication":{
    "blockUnknown": true,


### PR DESCRIPTION
Ensure that existing password are safe on solr restart.  If solr does need a restart, don't re-initialize the security.json file