### PR TITLE
Update logging config

### DIFF
--- a/ckan/setup/ckan.ini
+++ b/ckan/setup/ckan.ini
@@ -286,49 +286,55 @@ ckanext-archiver.cache_url_root={{ckan_site_domain}}
 keys = root, ckan, ckanext, werkzeug, saml2, model
 
 [handlers]
-keys = console
+keys = console,consoleerror
 
 [formatters]
 keys = generic
 
 [logger_root]
 level = WARNING
-handlers = console
+handlers = console,consoleerror
 
 [logger_werkzeug]
 level = WARNING
-handlers = console
+handlers = console,consoleerror
 qualname = werkzeug
 propagate = 0
 
 [logger_ckan]
 level = DEBUG
-handlers = console
+handlers = console,consoleerror
 qualname = ckan
 propagate = 0
 
 [logger_model]
 level = DEBUG
-handlers = console
+handlers = console,consoleerror
 qualname = ckan.model
 propagate = 0
 
 [logger_ckanext]
 level = DEBUG
-handlers = console
+handlers = console,consoleerror
 qualname = ckanext
 propagate = 0
 
 [logger_saml2]
 level = INFO
-handlers = console
+handlers = console,consoleerror
 qualname = saml2
 propagate = 0
 
 [handler_console]
 class = StreamHandler
-args = (sys.stderr,)
+args = (sys.stdout,)
 level = NOTSET
+formatter = generic
+
+[handler_consoleerror]
+class = StreamHandler
+args = (sys.stderr,)
+level = ERROR
 formatter = generic
 
 [formatter_generic]


### PR DESCRIPTION
Pulled from various best practices of Python logging. This should make standard debug, info, and warning messages appear as normal in stdout (and will be handled appropriately/as such in various log systems). Only actual errors should appear in stderr.

See https://docs.python.org/3/howto/logging.html#configuring-logging and https://stackoverflow.com/questions/25187083/python-logging-to-multiple-handlers-at-different-log-levels

*Update*: development deploy looks good, normal log output is clean while errors are highlighted per what you would expect:
![image](https://user-images.githubusercontent.com/26980513/174410640-a74a8852-7e8b-4a35-8b70-af94f4e5df16.png)
