### PR TITLE
added explicit cert envvar for egress proxy

### DIFF
--- a/.profile
+++ b/.profile
@@ -5,6 +5,9 @@ set -o pipefail
 
 echo "Running setup script..."
 
+echo "Setting CA Bundle.."
+export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 echo "java setup"
 
 export JAVA_HOME=/home/vcap/deps/0/apt/usr/lib/jvm/java-11-openjdk-amd64

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -4,14 +4,14 @@ Babel==2.9.1
 Beaker==1.11.0
 bleach==3.3.0
 boto==2.49.0
-certifi==2022.5.18.1
+certifi==2022.6.15
 cffi==1.15.0
 chardet==3.0.4
 ckan @ git+https://github.com/ckan/ckan.git@65af260bef26ea99981597f872d39da0a3f4f3f9
 -e git+https://github.com/GSA/ckanext-datagovcatalog.git@64e65702ae1eb5e46d9f37139dc4044c0f253526#egg=ckanext_datagovcatalog
 -e git+https://github.com/GSA/ckanext-datagovtheme.git@47c8ee24e4b61e69d680295e393a3d3bb971983f#egg=ckanext_datagovtheme
 -e git+https://github.com/GSA/ckanext-datajson.git@8258c00b4067c95ec142c4a610dc600c9e93cd41#egg=ckanext_datajson
-ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@0d51dbe9801fd66d3011af599fa54fbe57855122
+ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@2da97a9e60e11df34a7957add11fc51f8f900594
 ckanext-envvars @ git+https://github.com/GSA/ckanext-envvars.git@33f7e190ab332244cb961a425e09af592d9b647b
 -e git+https://github.com/GSA/ckanext-geodatagov.git@9482b89da3fde68ff26df4b23febdc2af0605770#egg=ckanext_geodatagov
 ckanext-googleanalyticsbasic @ git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@c6a425d5e14d658c0fa3661fdc4423162161c3f4
@@ -40,7 +40,7 @@ greenlet==1.1.2
 gunicorn==20.1.0
 html5lib==1.1
 idna==2.10
-importlib-resources==5.7.1
+importlib-resources==5.8.0
 isodate==0.6.1
 itsdangerous==2.1.2
 Jinja2==3.0.0
@@ -52,7 +52,7 @@ Mako==1.2.0
 Markdown==3.1.1
 MarkupSafe==2.1.1
 messytables==0.15.2
-newrelic==7.10.0.175
+newrelic==7.12.0.176
 nose==1.3.7
 OWSLib==0.18.0
 packaging==21.3
@@ -79,7 +79,7 @@ PyUtilib==5.7.1
 PyYAML==5.4
 PyZ3950 @ git+https://github.com/danizen/PyZ3950@6d44a4ab85c8bda3a7542c2c9efdfad46c830219
 rdflib==4.2.2
-redis==4.3.3
+redis==4.3.4
 repoze.lru==0.7
 repoze.who==2.3
 requests==2.25.0
@@ -101,7 +101,7 @@ WebOb==1.8.7
 Werkzeug==2.0.0
 wrapt==1.14.1
 xlrd==2.0.1
-xmlschema==1.11.1
+xmlschema==1.11.3
 zipp==3.8.0
 zope.event==4.5.0
 zope.interface==5.4.0


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3787

Apparently after all that, this is the minimum change that is needed to get egress to work. Only the `.profile` export is needed for this. The `requirements.txt` are just from updating dependencies.
