### PR TITLE
Use cdn

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -87,7 +87,7 @@ jobs:
       - name: deploy
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf push catalog --vars-file vars.development.yml --strategy rolling
+          command: cf push catalog-web --vars-file vars.development.yml --strategy rolling
           cf_org: gsa-datagov
           cf_space: development
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,7 @@ jobs:
       - name: deploy-ckan
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf push catalog --vars-file vars.staging.yml --strategy rolling
+          command: cf push catalog-web --vars-file vars.staging.yml --strategy rolling
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -208,7 +208,7 @@ jobs:
       - name: deploy-ckan
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf push catalog --vars-file vars.production.yml --strategy rolling
+          command: cf push catalog-web --vars-file vars.production.yml --strategy rolling
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -16,7 +16,7 @@ jobs:
    #     - name: restart
    #       uses: cloud-gov/cg-cli-tools@main
    #       with:
-   #         command: cf restart catalog --strategy rolling
+   #         command: cf restart catalog-web --strategy rolling
    #         cf_org: gsa-datagov
    #         cf_space: staging
    #         cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/run-harvest-check.yml
+++ b/.github/workflows/run-harvest-check.yml
@@ -24,7 +24,7 @@ jobs:
   #       uses: cloud-gov/cg-cli-tools@main
   #       with:
   #         command: |
-  #           cf run-task catalog --command 'ckan harvester run' --name 'harvester-check-completed (CI)' -k 2G
+  #           cf run-task catalog-gather --command 'ckan harvester run' --name 'harvester-check-completed (CI)' -k 2G
   #         cf_org: gsa-datagov
   #         cf_space: staging
   #         cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -39,7 +39,7 @@ jobs:
   #       uses: cloud-gov/cg-cli-tools@main
   #       with:
   #         command: |
-  #           cf run-task catalog --command 'ckan harvester run' --name 'harvester-check-completed (CI)' -k 2G
+  #           cf run-task catalog-gather --command 'ckan harvester run' --name 'harvester-check-completed (CI)' -k 2G
   #         cf_org: gsa-datagov
   #         cf_space: prod
   #         cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.profile
+++ b/.profile
@@ -58,7 +58,10 @@ SHARED_DIR=$(mktemp -d)
 # We need to know the application name ...
 export APP_NAME=$(echo $VCAP_APPLICATION | jq -r '.application_name')
 export REAL_NAME=$(echo $VCAP_APPLICATION | jq -r '.application_name')
-if [[ $APP_NAME = "catalog-gather" ]] || [[ $APP_NAME = "catalog-fetch" ]]; then
+if [[ $APP_NAME = "catalog-web" ]] || \
+   [[ $APP_NAME = "catalog-gather" ]] || \
+   [[ $APP_NAME = "catalog-fetch" ]]
+then
   APP_NAME=catalog
 fi
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,7 +12,7 @@ applications:
       - ((app_name))-solr
       - sysadmin-users
     routes:
-      - route: ((routes-internal))
+      - route: ((route-internal))
     health-check-type: http
     health-check-http-endpoint: /dataset
     health-check-invocation-timeout: 30
@@ -27,7 +27,7 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
-      CKAN_SITE_URL: https://((routes-external))
+      CKAN_SITE_URL: https://((route-external))
 
   - name: ((app_name))-proxy
     buildpacks:
@@ -36,11 +36,11 @@ applications:
     # TODO: tweak with load testing
     memory: 100M
     routes:
-      - route: ((routes-external))
+      - route: ((route-external))
     env:
-      PUBLIC_ROUTE: ((routes-public))
-      EXTERNAL_ROUTE: ((routes-external))
-      INTERNAL_ROUTE: ((routes-internal))
+      PUBLIC_ROUTE: ((route-public))
+      EXTERNAL_ROUTE: ((route-external))
+      INTERNAL_ROUTE: ((route-internal))
 
   - name: ((app_name))-gather
     buildpacks:
@@ -66,7 +66,7 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
-      CKAN_SITE_URL: https://((routes-external))
+      CKAN_SITE_URL: https://((route-external))
 
   - name: ((app_name))-fetch
     buildpacks:
@@ -90,4 +90,4 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
-      CKAN_SITE_URL: https://((routes-external))
+      CKAN_SITE_URL: https://((route-external))

--- a/manifest.yml
+++ b/manifest.yml
@@ -27,7 +27,7 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
-      CKAN_SITE_URL: https://((route-external))
+      CKAN_SITE_URL: https://((route-public))
 
   - name: ((app_name))-proxy
     buildpacks:
@@ -66,7 +66,7 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
-      CKAN_SITE_URL: https://((route-external))
+      CKAN_SITE_URL: https://((route-public))
 
   - name: ((app_name))-fetch
     buildpacks:
@@ -90,4 +90,4 @@ applications:
       NEW_RELIC_APP_NAME: ((new_relic_app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
-      CKAN_SITE_URL: https://((route-external))
+      CKAN_SITE_URL: https://((route-public))

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 # To apply this manifest: cf push --vars-file vars.yml
 applications:
-  - name: ((app_name))
+  - name: ((app_name))-web
     buildpacks:
       - https://github.com/cloudfoundry/apt-buildpack
       - python_buildpack

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -31,7 +31,7 @@ http {
     client_max_body_size 250M;
 
     # set the correct host(s) for your site
-    server_name {{env "PUBLIC_ROUTE"}}
+    server_name {{env "PUBLIC_ROUTE"}};
 
     keepalive_timeout 5;
 

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -31,7 +31,7 @@ http {
     client_max_body_size 250M;
 
     # set the correct host(s) for your site
-    server_name {{env "PUBLIC_ROUTE"}};
+    server_name {{env "EXTERNAL_ROUTE"}};
 
     keepalive_timeout 5;
 

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -31,7 +31,7 @@ http {
     client_max_body_size 250M;
 
     # set the correct host(s) for your site
-    server_name {{env "PUBLIC_ROUTE"}} {{env "EXTERNAL_ROUTE"}};
+    server_name {{env "PUBLIC_ROUTE"}}
 
     keepalive_timeout 5;
 

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -12,8 +12,9 @@ gather_memory_quota: 1G
 
 new_relic_app_name: catalog (develop)
 new_relic_monitor_mode: false
-  
-route-public:
+
+# use CDN domain for route-public if available, otherwise use router-external 
+route-public: d2jqk88ququ1n9.cloudfront.net
 route-external: catalog-dev-datagov.app.cloud.gov
 route-internal: catalog-dev-datagov.apps.internal
 

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -13,7 +13,7 @@ gather_memory_quota: 1G
 new_relic_app_name: catalog (develop)
 new_relic_monitor_mode: false
 
-# use CDN domain for route-public if available, otherwise use router-external 
+# use CDN domain for route-public if available, otherwise use route-external 
 route-public: d2jqk88ququ1n9.cloudfront.net
 route-external: catalog-dev-datagov.app.cloud.gov
 route-internal: catalog-dev-datagov.apps.internal

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -12,10 +12,10 @@ gather_memory_quota: 1G
 
 new_relic_app_name: catalog (develop)
 new_relic_monitor_mode: false
-
-routes-public:
-routes-external: catalog-dev-datagov.app.cloud.gov
-routes-internal: catalog-dev-datagov.apps.internal
+  
+route-public:
+route-external: catalog-dev-datagov.app.cloud.gov
+route-internal: catalog-dev-datagov.apps.internal
 
 saml2_certificate: |
   -----BEGIN CERTIFICATE-----

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -13,7 +13,7 @@ gather_memory_quota: 3G
 new_relic_app_name: catalog
 new_relic_monitor_mode: true
 
-# use CDN domain for route-public if available, otherwise use router-external 
+# use CDN domain for route-public if available, otherwise use route-external 
 route-public: drclmjip6pfj0.cloudfront.net
 route-external: catalog-prod-datagov.app.cloud.gov
 route-internal: catalog-prod-datagov.apps.internal

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -13,9 +13,9 @@ gather_memory_quota: 3G
 new_relic_app_name: catalog
 new_relic_monitor_mode: true
 
-routes-public: catalog.data.gov
-routes-external: catalog-prod-datagov.app.cloud.gov
-routes-internal: catalog-prod-datagov.apps.internal
+route-public: catalog.data.gov
+route-external: catalog-prod-datagov.app.cloud.gov
+route-internal: catalog-prod-datagov.apps.internal
 
 saml2_certificate: |
   -----BEGIN CERTIFICATE-----

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -13,7 +13,8 @@ gather_memory_quota: 3G
 new_relic_app_name: catalog
 new_relic_monitor_mode: true
 
-route-public: catalog.data.gov
+# use CDN domain for route-public if available, otherwise use router-external 
+route-public: drclmjip6pfj0.cloudfront.net
 route-external: catalog-prod-datagov.app.cloud.gov
 route-internal: catalog-prod-datagov.apps.internal
 

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -13,7 +13,7 @@ gather_memory_quota: 3G
 new_relic_app_name: catalog (staging)
 new_relic_monitor_mode: true
 
-# use CDN domain for route-public if available, otherwise use router-external 
+# use CDN domain for route-public if available, otherwise use route-external 
 route-public: d1u59lafwydg4a.cloudfront.net
 route-external: catalog-stage-datagov.app.cloud.gov
 route-internal: catalog-stage-datagov.apps.internal

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -13,9 +13,9 @@ gather_memory_quota: 3G
 new_relic_app_name: catalog (staging)
 new_relic_monitor_mode: true
 
-routes-public:
-routes-external: catalog-stage-datagov.app.cloud.gov
-routes-internal: catalog-stage-datagov.apps.internal
+route-public:
+route-external: catalog-stage-datagov.app.cloud.gov
+route-internal: catalog-stage-datagov.apps.internal
 
 saml2_certificate: |
   -----BEGIN CERTIFICATE-----

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -13,7 +13,8 @@ gather_memory_quota: 3G
 new_relic_app_name: catalog (staging)
 new_relic_monitor_mode: true
 
-route-public:
+# use CDN domain for route-public if available, otherwise use router-external 
+route-public: d1u59lafwydg4a.cloudfront.net
 route-external: catalog-stage-datagov.app.cloud.gov
 route-internal: catalog-stage-datagov.apps.internal
 


### PR DESCRIPTION
mostly some refactoring to prepare cloud.gov migration
- rename catalog app to catalog-web.
- use temp CDN name for catalog-web apps.

Post deployment
- delete existing catalog apps.
- add new network-policy allowing traffic from catalog-proxy to catalog-web.
- use permanent CDN names.
