### PR TITLE
increase cache to 24 hours to be safe

### DIFF
--- a/ckan/setup/ckan.ini
+++ b/ckan/setup/ckan.ini
@@ -41,7 +41,7 @@ beaker.session.url = $CKAN___BEAKER__SESSION__URL
 beaker.session.timeout=900
 
 # CKAN caching
-ckan.cache_expires = 3600
+ckan.cache_expires = 86400
 ckan.cache_enabled = True
 
 # `ckan generate config` generates a unique value for this each time it generates


### PR DESCRIPTION
will change back to normal 1 hour after settling down at cloud.gov