### PR TITLE
Solr on ECS - fix order of start script

### DIFF
--- a/solr/solr_setup.sh
+++ b/solr/solr_setup.sh
@@ -5,10 +5,18 @@ mkdir -p /tmp/ckan_config
 # Remove any residual EFS backups
 rm -rf /var/solr/data/aws-backup-restore*
 
+# add solr config files for ckan 2.9
+wget -O /tmp/ckan_config/schema.xml https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/managed-schema
+wget -O /tmp/ckan_config/protwords.txt https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/protwords.txt
+wget -O /tmp/ckan_config/solrconfig.xml https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/solrconfig.xml
+wget -O /tmp/ckan_config/solrconfig_follower.xml https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/solrconfig_follower.xml
+wget -O /tmp/ckan_config/stopwords.txt https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/stopwords.txt
+wget -O /tmp/ckan_config/synonyms.txt https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/synonyms.txt
+
 # Check if users already exist
 SECURITY_FILE=/var/solr/data/security.json
 if [ -f "$SECURITY_FILE" ]; then
-  echo "Solr ckan and authentication are set up already :)"
+  echo "Solr authentication are set up already :)"
   exit 0;
 fi
 
@@ -29,14 +37,6 @@ cat <<SOLRAUTH > $SECURITY_FILE
    "user-role":{"catalog":"admin"}
 }}
 SOLRAUTH
-
-# add solr config files for ckan 2.9
-wget -O /tmp/ckan_config/schema.xml https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/managed-schema
-wget -O /tmp/ckan_config/protwords.txt https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/protwords.txt
-wget -O /tmp/ckan_config/solrconfig.xml https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/solrconfig.xml
-wget -O /tmp/ckan_config/solrconfig_follower.xml https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/solrconfig_follower.xml
-wget -O /tmp/ckan_config/stopwords.txt https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/stopwords.txt
-wget -O /tmp/ckan_config/synonyms.txt https://raw.githubusercontent.com/GSA/catalog.data.gov/main/ckan/setup/solr/synonyms.txt
 
 #  group user solr:solr is 8983:8983 in solr docker image
 chown -R 8983:8983 /var/solr/data/


### PR DESCRIPTION
Related to 
- https://github.com/GSA/data.gov/issues/2788

- move solr config file download before security.json check
  - we may need to clear the core sometimes to revive a bad follower this change ensure we have solr config file even there is security.json