### PR TITLE
Block languages and verify blocked

### DIFF
--- a/.env
+++ b/.env
@@ -148,3 +148,6 @@ CKANEXT__SAML2AUTH__REQUESTED_AUTHN_CONTEXT_COMPARISON=exact
 
 # Avoid double package_show call to add tracking info
 CKANEXT__DATAGOVCATALOG__ADD_PACKAGES_TRACKING_INFO=false
+
+# Remove all translated pages, for less crawling
+CKAN__LOCALES_FILTERED_OUT=am ar bg ca cs_CZ da_DK de el en_AU en_GB es es_AR eu fa_IR fi fr gl he hr hu id is it ja km ko_KR lt lv mk mn_MN my_MM nb_NO ne nl pl pt_BR pt_PT ro ru sk sl sq sr sr_Latn sv th tl tr uk uk_UA vi zh_Hans_CN zh_Hant_TW

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -95,7 +95,7 @@ jobs:
       - name: deploy proxy
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf push catalog-proxy --vars-file vars.staging.yml --strategy rolling
+          command: cf push catalog-proxy --vars-file vars.development.yml --strategy rolling
           cf_org: gsa-datagov
           cf_space: development
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -92,6 +92,14 @@ jobs:
           cf_space: development
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: deploy proxy
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: cf push catalog-proxy --vars-file vars.staging.yml --strategy rolling
+          cf_org: gsa-datagov
+          cf_space: development
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
       - name: deploy admin
         uses: cloud-gov/cg-cli-tools@main
         with:

--- a/ckan/setup/ckan.ini
+++ b/ckan/setup/ckan.ini
@@ -168,9 +168,9 @@ ckan.template_head_end = <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/
 
 ## Internationalisation Settings
 ckan.locale_default = en
-ckan.locale_order = en pt_BR ja it cs_CZ ca es fr el sv sr sr@latin no sk fi ru de pl nl bg ko_KR hu sa sl lv
-ckan.locales_offered =
-ckan.locales_filtered_out = en_GB
+# ckan.locale_order = en pt_BR ja it cs_CZ ca es fr el sv sr sr@latin no sk fi ru de pl nl bg ko_KR hu sa sl lv
+# ckan.locales_offered =
+ckan.locales_filtered_out = am ar bg ca cs_CZ da_DK de el en_AU en_GB es es_AR eu fa_IR fi fr gl he hr hu id is it ja km ko_KR lt lv mk mn_MN my_MM nb_NO ne nl pl pt_BR pt_PT ro ru sk sl sq sr sr_Latn sv th tl tr uk uk_UA vi zh_Hans_CN zh_Hant_TW
 
 ## Feeds Settings
 

--- a/e2e/cypress/integration/language.js
+++ b/e2e/cypress/integration/language.js
@@ -1,0 +1,5 @@
+describe('language', () => {
+    it("Doesn't have french page", () => {
+        cy.request({url: '/fr/dataset', failOnStatusCode: false}).its('status').should('equal', 404)
+    });
+})

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -38,11 +38,6 @@ http {
     # path for static files
     root ./public;
 
-    # redirect all locales to the default english
-    location ~ ^/(am|ar|bg|ca|cs_CZ|da_DK|de|el|en_AU|en_GB|es|es_AR|eu|fa_IR|fi|fr|gl|he|hr|hu|id|is|it|ja|km|ko_KR|lt|lv|mk|mn_MN|my_MM|nb_NO|ne|nl|pl|pt_BR|pt_PT|ro|ru|sk|sl|sq|sr|sr_Latn|sv|th|tl|tr|uk|uk_UA|vi|zh_Hans_CN|zh_Hant_TW)/(.*) {
-      return  301 $scheme://{{env "PUBLIC_ROUTE"}}/$2;
-    }
-
     location / {
       # Protect catalog from expensive API calls
       rewrite ^/api/rest/dataset$ $scheme://{{env "PUBLIC_ROUTE"}}/api/action/package_search redirect;


### PR DESCRIPTION
Remove custom nginx and use CKAN config to manage accepted language pages.

Related to https://github.com/GSA/data.gov/issues/2788

Confirmed on development:
![image](https://user-images.githubusercontent.com/26980513/182660441-bf19d8a8-b5a9-4d83-baaa-8baf3e71e95d.png)
