### PR TITLE
allow health check

### DIFF
--- a/proxy/nginx-cloudfront.conf
+++ b/proxy/nginx-cloudfront.conf
@@ -3,15 +3,21 @@
 set $onlyCF "";
 set $somevariable {{env "EXTERNAL_ROUTE"}};
 
+# health check is always allowed
+# with this value inserted, $onlyCF will not trigger 403
+if ($uri = "/api/action/status_show") {
+  set $onlyCF "${onlyCF}letMeIn,";
+}
+
 if ($somevariable != {{env "PUBLIC_ROUTE"}}) {
-  set $onlyCF "onCDN";
+  set $onlyCF "${onlyCF}onCDN,";
 }
 
 if ($http_user_agent != "Amazon CloudFront") {
-  set $onlyCF "${onlyCF}+notFromCF";
+  set $onlyCF "${onlyCF}notFromCF";
 }
 
-if ($onlyCF = "onCDN+notFromCF") {
+if ($onlyCF = "onCDN,notFromCF") {
   #TODO custom 403 message
   return 403;
 }


### PR DESCRIPTION
Should have gone with https://github.com/GSA/catalog.data.gov/pull/512

When catalog app is behind CDN, we limited traffic from CloudFront user-agent only, effectively blocking direct traffic to `*.app.cloud.gov` external URL. But we should allow health check traffic at `/api/action/status_show` .