### PR TITLE
Allow api auth to pass through to admin

### DIFF
--- a/proxy/nginx-authy.conf
+++ b/proxy/nginx-authy.conf
@@ -13,6 +13,9 @@ if ($uri = "/acs") {
 if ($uri = "/api/action/status_show") {
   set $authy "${authy}H";
 }
+if ($http_authorization) {
+  set $authy "${authy}A";
+}
 # If not logged in and not trying to login, redirect
 if ($authy = "") {
   return 302 https://{{env "PUBLIC_ROUTE"}}$request_uri;


### PR DESCRIPTION
Related to inability to de-dupe datasets on cloud.gov prod.

This will allow api calls with api key to pass through to CKAN admin, which will check for correct authorization.