### PR TITLE
Add test for checking duplicates

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -10,7 +10,7 @@ chardet==3.0.4
 ckan @ git+https://github.com/ckan/ckan.git@65af260bef26ea99981597f872d39da0a3f4f3f9
 ckanext-datagovcatalog==0.0.3
 ckanext-datagovtheme==0.1.2
-ckanext-datajson==0.1.1
+ckanext-datajson==0.1.2
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@27db0318ccfeb9ffde6ab70357be3572d82092c8
 ckanext-envvars==0.0.2
 ckanext-geodatagov==0.1.2

--- a/e2e/cypress/integration/re-harvest.spec.js
+++ b/e2e/cypress/integration/re-harvest.spec.js
@@ -2,6 +2,7 @@ describe('Harvest', () => {
     // Rename this only if necessary, various test dependencies
     const harvestOrg = 'test-harvest-org';
     const wafIsoHarvestSourceName = 'test-harvest-waf-iso';
+    const dataJsonHarvestSoureName = 'test-harvest-datajson';
 
     before(() => {
         cy.login();
@@ -41,4 +42,15 @@ describe('Harvest', () => {
             expect(duplicate_keys).to.be.empty;
         });
     });
+
+    it('Re-harvest data json', () => {
+        cy.start_harvest_job(dataJsonHarvestSoureName);
+    });
+
+    it('No datasets are duplicated in datajson', () => {
+        const dataset_title = '2015 GSA Common Baseline Implementation Plan and CIO Assignment Plan';
+        cy.request(`/api/action/package_search?q=name:"${dataset_title}"`).should((response) => {
+            expect(response.body.result.count).to.equal(1)
+        })
+    })
 });

--- a/e2e/cypress/integration/re-harvest.spec.js
+++ b/e2e/cypress/integration/re-harvest.spec.js
@@ -49,7 +49,7 @@ describe('Harvest', () => {
 
     it('No datasets are duplicated in datajson', () => {
         const dataset_title = '2015 GSA Common Baseline Implementation Plan and CIO Assignment Plan';
-        cy.request(`/api/action/package_search?q=name:"${dataset_title}"`).should((response) => {
+        cy.request(`/api/action/package_search?q=title:"${dataset_title}"`).should((response) => {
             expect(response.body.result.count).to.equal(1)
         })
     })


### PR DESCRIPTION
Still needs to pull in https://github.com/GSA/ckanext-datajson/pull/120 (update ckanext-datajson to `0.1.2`).

Expect first tests to fail, but expect once datajson is upgraded that tests will pass.