### PR TITLE
use simple solr locktype; add retry in case of lock

### DIFF
--- a/solr/local_setup.sh
+++ b/solr/local_setup.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+set -e
+
 # Setup ckan core config
 /app/solr/solr_setup.sh
 
 # Start solr
-su -c "init-var-solr; precreate-core ckan /tmp/ckan_config; chown -R 8983:8983 /var/solr/data; solr-fg" -m solr
+su -c "init-var-solr; precreate-core ckan /tmp/ckan_config; chown -R 8983:8983 /var/solr/data; solr-fg -Dsolr.lock.type=simple" -m solr


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3920

Use `simple` LockType and some retry logic to have a successful Solr Task restart without Core file being locked or Core file be corrupted.