### PR TITLE
change idp to login.gov prod

### DIFF
--- a/vars.production.yml
+++ b/vars.production.yml
@@ -2,7 +2,7 @@
 app_name: catalog
 
 ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-prod-catalog
-ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.sandbox.idp.xml
+ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.production.idp.xml
 
 web-instances: 5
 admin-instances: 1

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -2,7 +2,7 @@
 app_name: catalog
 
 ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-stage-catalog
-ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.sandbox.idp.xml
+ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.production.idp.xml
 
 web-instances: 2
 admin-instances: 1


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/2788
catalog staging and production apps will be promoted to login.gov prod on August 25, 2022.