### PR TITLE
Allow CORS for data.gov

### DIFF
--- a/ckan/setup/ckan.ini
+++ b/ckan/setup/ckan.ini
@@ -115,11 +115,9 @@ ckan.site_id = datagov_catalog
 
 ## CORS Settings
 
-# If cors.origin_allow_all is true, all origins are allowed.
-# If false, the cors.origin_whitelist is used.
-# ckan.cors.origin_allow_all = true
-# cors.origin_whitelist is a space separated list of allowed domains.
-# ckan.cors.origin_whitelist = http://example1.com http://example2.com
+# Allow dataset count to populate on data.gov
+ckan.cors.origin_allow_all = False
+ckan.cors.origin_whitelist = https://data.gov https://www.data.gov
 
 
 ## Plugins Settings


### PR DESCRIPTION
Related to 
- https://github.com/GSA/data.gov/issues/3891
- https://github.com/GSA/inventory-app/pull/444

To support dataset count gathering, open catalog.data.gov to data.gov