### PR TITLE
Add CORS origin in nginx proxy

### DIFF
--- a/ckan/setup/ckan.ini
+++ b/ckan/setup/ckan.ini
@@ -115,9 +115,7 @@ ckan.site_id = datagov_catalog
 
 ## CORS Settings
 
-# Allow dataset count to populate on data.gov
-ckan.cors.origin_allow_all = False
-ckan.cors.origin_whitelist = https://data.gov https://www.data.gov
+# Does not work
 
 
 ## Plugins Settings

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -32,6 +32,7 @@ http {
   ## Gunicorn specs
   server {
     # catalog-web
+    add_header 'Access-Control-Allow-Origin' 'https://data.gov';
     server_name {{env "EXTERNAL_ROUTE"}};
 
     include nginx-cloudfront.conf;


### PR DESCRIPTION
Fixes
- #529 

The CKAN configuration does not work, so add it to the Proxy instead.