### PR TITLE
Only run db inits on flag

### DIFF
--- a/.profile
+++ b/.profile
@@ -135,9 +135,11 @@ ckan config-tool $CKAN_INI -s DEFAULT -e debug=false
 
 echo Running ckan setup commands
 
-# Run migrations
-ckan db upgrade
-ckan harvester initdb
-ckan archiver init
-ckan report initdb
-ckan qa init
+if [[ $MIGRATE_DB = 'True' ]]; then
+  # Run migrations
+  ckan db upgrade
+  ckan harvester initdb
+  ckan archiver init
+  ckan report initdb
+  ckan qa init
+fi


### PR DESCRIPTION
## Related to
- https://github.com/GSA/data.gov/issues/3973

## Changes
This should speed up the startup process and also run-task commands

To run the migrations, just do 
```bash
cf set-env catalog-web MIGRATE_DB True
cf run-task catalog-web -c "ls"  # (`ls` would work because the .profile gets run every time)
cf unset-env catalog-web MIGRATE_DB
```

## Keywords (to help search for this issue in the future):
- db, database
- migration, migrate
- init, initialization