### PR TITLE
Ceate issue for other failures too!

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,20 @@ jobs:
           name: python-vendored
           path: vendor/
           if-no-files-found: error
+      - name: Create Issue if it fails 😢
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GITHUB_JOB: ${{ toJson(github)['job'] }}
+          GITHUB_ATTEMPTS: ${{ github.run_attempt }}
+          LAST_COMMIT: ${{ github.sha }}
+          LAST_RUN_BY: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          filename: .github/deploy_failure.md
+          assignees: ${{ github.actor }}
+          update_existing: true
 
   create-cloudgov-services-staging:
     name: create services (staging)
@@ -130,6 +144,20 @@ jobs:
           sleep 10
           curl --fail --silent https://catalog-stage-datagov.app.cloud.gov\
           /api/action/status_show?$(date +%s)
+      - name: Create Issue if it fails 😢
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GITHUB_JOB: ${{ toJson(github)['job'] }}
+          GITHUB_ATTEMPTS: ${{ github.run_attempt }}
+          LAST_COMMIT: ${{ github.sha }}
+          LAST_RUN_BY: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          filename: .github/deploy_failure.md
+          assignees: ${{ github.actor }}
+          update_existing: true
 
   deploy-prod:
     name: deploy catalog (prod)
@@ -180,7 +208,7 @@ jobs:
         if: ${{ failure() }}
         uses: JasonEtco/create-an-issue@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
           GITHUB_JOB: ${{ toJson(github)['job'] }}
           GITHUB_ATTEMPTS: ${{ github.run_attempt }}
           LAST_COMMIT: ${{ github.sha }}

--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -6,50 +6,64 @@ on:   # yamllint disable-line rule:truthy
     - cron: '11/30 * * * *'
 
 jobs:
-  # restart-staging:
-  #   name: restart (staging)
-  #   environment: staging
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: restart catalog-web
-  #       uses: cloud-gov/cg-cli-tools@main
-  #       with:
-  #         command: cf restart catalog-web --strategy rolling
-  #         cf_org: gsa-datagov
-  #         cf_space: staging
-  #         cf_username: ${{secrets.CF_SERVICE_USER}}
-  #         cf_password: ${{secrets.CF_SERVICE_AUTH}}
-  #     - name: restart catalog-admin
-  #       uses: cloud-gov/cg-cli-tools@main
-  #       with:
-  #         command: cf restart catalog-admin --strategy rolling
-  #         cf_org: gsa-datagov
-  #         cf_space: staging
-  #         cf_username: ${{secrets.CF_SERVICE_USER}}
-  #         cf_password: ${{secrets.CF_SERVICE_AUTH}}
-  #     # - name: restart gather
-  #     #   uses: cloud-gov/cg-cli-tools@main
-  #     #   with:
-  #     #     command: cf restart catalog-gather
-  #     #     cf_org: gsa-datagov
-  #     #     cf_space: staging
-  #     #     cf_username: ${{secrets.CF_SERVICE_USER}}
-  #     #     cf_password: ${{secrets.CF_SERVICE_AUTH}}
-  #     - name: restart fetch
-  #       uses: cloud-gov/cg-cli-tools@main
-  #       with:
-  #         command: cf restart catalog-fetch
-  #         cf_org: gsa-datagov
-  #         cf_space: staging
-  #         cf_username: ${{secrets.CF_SERVICE_USER}}
-  #         cf_password: ${{secrets.CF_SERVICE_AUTH}}
-  #     - name: smoke test
-  #       run: |
-  #         sleep 10
-  #         curl --fail --silent https://catalog-stage-datagov.app.cloud.gov \
-  #         /api/action/status_show?$(date +%s)
+  restart-staging:
+    name: restart (staging)
+    environment: staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: restart catalog-web
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: cf restart catalog-web --strategy rolling
+          cf_org: gsa-datagov
+          cf_space: staging
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: restart catalog-admin
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: cf restart catalog-admin --strategy rolling
+          cf_org: gsa-datagov
+          cf_space: staging
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: restart gather
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: tools/restart_harvester.sh catalog-gather
+          cf_org: gsa-datagov
+          cf_space: prod
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: restart fetch
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: tools/restart_harvester.sh catalog-fetch
+          cf_org: gsa-datagov
+          cf_space: prod
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: smoke test
+        run: |
+          sleep 10
+          curl --fail --silent https://catalog-stage-datagov.app.cloud.gov \
+          /api/action/status_show?$(date +%s)
+      - name: Create Issue if it fails 😢
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GITHUB_JOB: ${{ toJson(github)['job'] }}
+          GITHUB_ATTEMPTS: ${{ github.run_attempt }}
+          LAST_COMMIT: ${{ github.sha }}
+          LAST_RUN_BY: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          filename: .github/deploy_failure.md
+          assignees: ${{ github.actor }}
+          update_existing: true
 
   restart-prod:
     name: restart (prod)
@@ -95,3 +109,17 @@ jobs:
           sleep 10
           curl --fail --silent https://catalog.data.gov\
           /api/action/status_show?$(date +%s)
+      - name: Create Issue if it fails 😢
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GITHUB_JOB: ${{ toJson(github)['job'] }}
+          GITHUB_ATTEMPTS: ${{ github.run_attempt }}
+          LAST_COMMIT: ${{ github.sha }}
+          LAST_RUN_BY: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          filename: .github/deploy_failure.md
+          assignees: ${{ github.actor }}
+          update_existing: true


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/2827
- https://github.com/GSA/catalog.data.gov/issues/582

Changes:
- Use a different token to create issues so that it doesn't prevent the add-to-project workflow from running

Reference courtesy of @jbrown-xentity:
- https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-536184102