### PR TITLE
Limit length of archiver download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ update-tracking-info:
 
 harvest:
 	# Pass any of the following arguments to run them
-	# make harvest 'fetch-consumer'
-	# make harvest 'gather-consumer'
-	# make harvest 'run'
+	# ARGS=run make harvest
+	# ARGS=gather-consumer make harvest
+	# ARGS=fetch-consumer make harvest
 	docker-compose exec ckan ckan harvester $(ARGS)

--- a/ckan/setup/ckan.ini
+++ b/ckan/setup/ckan.ini
@@ -284,6 +284,7 @@ ckanext.datagovtheme.use.qa=false
 # Archiver Settings
 
 ckanext-archiver.cache_url_root={{ckan_site_domain}}
+ckanext-archiver.max_content_length=10240
 
 ## Logging configuration
 [loggers]


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/3986
- https://github.com/GSA/data.gov/issues/3965

References:
- https://github.com/ckan/ckanext-archiver/blob/c96e3c81bfc430cdb0372f3307c7abd4109a80f1/ckanext/archiver/default_settings.py

![image](https://user-images.githubusercontent.com/85196563/196296444-6ac904a5-6e7b-412b-bb8b-5d0a282864d2.png)
