### PR TITLE
Change logging level DEBUG to INFO

### DIFF
--- a/ckan/setup/ckan.ini
+++ b/ckan/setup/ckan.ini
@@ -307,19 +307,19 @@ qualname = werkzeug
 propagate = 0
 
 [logger_ckan]
-level = DEBUG
+level = INFO
 handlers = console,consoleerror
 qualname = ckan
 propagate = 0
 
 [logger_model]
-level = DEBUG
+level = INFO
 handlers = console,consoleerror
 qualname = ckan.model
 propagate = 0
 
 [logger_ckanext]
-level = DEBUG
+level = INFO
 handlers = console,consoleerror
 qualname = ckanext
 propagate = 0


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3833

There are way too many logs... I don't think we need debug level info at this time, just INFO.