### PR TITLE
Fix staging restart smoke test

### DIFF
--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -48,7 +48,7 @@ jobs:
       - name: smoke test
         run: |
           sleep 10
-          curl --fail --silent https://catalog-stage-datagov.app.cloud.gov \
+          curl --fail --silent https://catalog-stage-datagov.app.cloud.gov\
           /api/action/status_show?$(date +%s)
       - name: Create Issue if it fails 😢
         if: ${{ failure() }}


### PR DESCRIPTION
Prod smoke test seems to work, staging doesn't.  The only difference is the space :/

![image](https://user-images.githubusercontent.com/85196563/196473998-75226e27-206e-4107-85cb-3da511c8fde3.png)
