### PR TITLE
Change new-relic app name

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -25,7 +25,7 @@ applications:
       CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH: ((ckanext__saml2auth__idp_metadata__local_path))
       CKANEXT__SAML2AUTH__ENTITY_ID: ((ckanext__saml2auth__entity_id))
       SAML2_CERTIFICATE: ((saml2_certificate))
-      NEW_RELIC_APP_NAME: ((new_relic_app_name))
+      NEW_RELIC_APP_NAME: ((app_name))-web-((space_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
       CKAN_SITE_URL: https://((route-public))
@@ -54,7 +54,7 @@ applications:
       CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH: ((ckanext__saml2auth__idp_metadata__local_path))
       CKANEXT__SAML2AUTH__ENTITY_ID: ((ckanext__saml2auth__entity_id))
       SAML2_CERTIFICATE: ((saml2_certificate))
-      NEW_RELIC_APP_NAME: ((new_relic_app_name))
+      NEW_RELIC_APP_NAME: ((app_name))-admin-((space_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
       CKAN_SITE_URL: https://((route-external-admin))
@@ -98,7 +98,7 @@ applications:
       CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH: ((ckanext__saml2auth__idp_metadata__local_path))
       CKANEXT__SAML2AUTH__ENTITY_ID: ((ckanext__saml2auth__entity_id))
       SAML2_CERTIFICATE: ((saml2_certificate))
-      NEW_RELIC_APP_NAME: ((new_relic_app_name))
+      NEW_RELIC_APP_NAME: ((app_name))-gather-((space_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
       CKAN_SITE_URL: https://((route-public))
@@ -123,7 +123,7 @@ applications:
       CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH: ((ckanext__saml2auth__idp_metadata__local_path))
       CKANEXT__SAML2AUTH__ENTITY_ID: ((ckanext__saml2auth__entity_id))
       SAML2_CERTIFICATE: ((saml2_certificate))
-      NEW_RELIC_APP_NAME: ((new_relic_app_name))
+      NEW_RELIC_APP_NAME: ((app_name))-fetch-((space_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
       CKAN_SITE_URL: https://((route-public))

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -1,5 +1,6 @@
 # This is the name to use for the development catalog app in Cloud Foundry
 app_name: catalog
+space_name: development
 
 ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-dev-catalog
 ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.sandbox.idp.xml
@@ -11,7 +12,6 @@ fetch-instances: 1
 memory_quota: 750M
 gather_memory_quota: 1G
 
-new_relic_app_name: catalog (develop)
 new_relic_monitor_mode: false
 
 # use CDN domain for route-public if available, otherwise use route-external 

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -1,5 +1,6 @@
 # This is the name to use for the staging catalog app in Cloud Foundry
 app_name: catalog
+space_name: prod
 
 ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-prod-catalog
 ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.production.idp.xml
@@ -11,7 +12,6 @@ fetch-instances: 4
 memory_quota: 850M
 gather_memory_quota: 3G
 
-new_relic_app_name: catalog
 new_relic_monitor_mode: true
 
 # use CDN domain for route-public if available, otherwise use route-external 

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -1,5 +1,6 @@
 # This is the name to use for the staging catalog app in Cloud Foundry
 app_name: catalog
+space_name: staging
 
 ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-stage-catalog
 ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.production.idp.xml
@@ -11,7 +12,6 @@ fetch-instances: 0
 memory_quota: 850M
 gather_memory_quota: 3G
 
-new_relic_app_name: catalog (staging)
 new_relic_monitor_mode: true
 
 # use CDN domain for route-public if available, otherwise use route-external 


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3991

We currently can't distinguish in the logs between catalog-web, admin, fetch, and gather. This should accomplish that.

There will be a follow up to setup catalog-web and catalog-admin with alerts as before inside New Relic (since they will have a new name), but this will allow us to target certain applications/processes for alerts better as well.