### PR TITLE
Fix false restart failures

### DIFF
--- a/tools/restart.sh
+++ b/tools/restart.sh
@@ -16,5 +16,5 @@ instances=$(cf app $app_to_restart | grep '^instances:' | sed 's/.*\///')
 for (( i=1; i<=$instances; i++ ))
 do
   cf restart-app-instance $app_to_restart $((i-1))
-  # sleep 90
+  sleep 90
 done;

--- a/tools/restart.sh
+++ b/tools/restart.sh
@@ -5,11 +5,16 @@
 # Input any app name
 app_to_restart=$1
 
+# If there is more than one instance of 'instances', the app is already restarting
+if [[ $(cf app $app_to_restart | grep '^instances:' | wc -l) > 1 ]]; then
+  echo "Deployment or Restart in progress... not doing anything"
+  exit 0
+fi
+
 instances=$(cf app $app_to_restart | grep '^instances:' | sed 's/.*\///')
 
-# for i in {1..$((instances))}
 for (( i=1; i<=$instances; i++ ))
 do
   cf restart-app-instance $app_to_restart $((i-1))
-  sleep 90
+  # sleep 90
 done;


### PR DESCRIPTION
Related to
- #595 

```bash

API endpoint:   https://api.fr.cloud.gov/
API version:    3.126.0

Not logged in. Use 'cf login' or 'cf login --sso' to log in.
API endpoint: https://api.fr.cloud.gov/

Authenticating...
OK

Use 'cf target' to view or set your target org and space.
API endpoint:   https://api.fr.cloud.gov/
API version:    3.126.0
user:           ***
org:            gsa-datagov
space:          prod
Running command: tools/restart.sh catalog-web
tools/restart.sh: line 11: ((: i<=2
4: syntax error in expression (error token is "4")
```