### PR TITLE
Fix sed with / in URL

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -41,6 +41,7 @@ applications:
       - ((app_name))-secrets
       - ((app_name))-solr
       - ((app_name))-smtp
+      - ((app_name))-s3
       - sysadmin-users
     routes:
       - route: ((route-internal-admin))
@@ -65,6 +66,7 @@ applications:
       - https://github.com/cloudfoundry/nginx-buildpack
     services:
       - ((app_name))-secrets
+      - ((app_name))-s3
     path: ./proxy
     # TODO: tweak with load testing
     memory: 100M

--- a/proxy/.profile
+++ b/proxy/.profile
@@ -38,4 +38,4 @@ S3_URL=https://$(vcap_get_service s3 .credentials.endpoint)
 S3_BUCKET=$(vcap_get_service s3 .credentials.bucket)
 SITEMAP_URL="$S3_URL/$S3_BUCKET/sitemap.xml"
 # replaces value in robots.txt, maybe update this to nice url?
-sed -i "s/SITEMAP_URL/${SITEMAP_URL}/" ./public/robots.txt
+sed -i "s,SITEMAP_URL,${SITEMAP_URL}," ./public/robots.txt


### PR DESCRIPTION
Fixes proxy deployment, errors with sed and url with `/`. See [recent failures](https://github.com/GSA/catalog.data.gov/actions/workflows/publish.yml). Found in recent debugging.