### PR TITLE
Revert to basic fetch command with recent fixes

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -119,7 +119,7 @@ applications:
     no-route: true
     instances: ((fetch-instances))
     disk_quota: 1.5G
-    command: newrelic-admin run-program while ! ckan harvester fetch-consumer; do sleep 1; done
+    command: newrelic-admin run-program ckan harvester fetch-consumer
     health-check-type: process
     timeout: 15
     env:


### PR DESCRIPTION
Catalog-fetch fails to deploy, and is in a bad state. Would rather have slow fetch jobs with insight into what's happening, than fast jobs that fail all the time and we don't know why...