### PR TITLE
Add concurrency so we don't get superseeded

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -81,6 +81,7 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     name: deploy (development)
     environment: development
+    concurrency: catalog-development-deployment
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,6 +104,7 @@ jobs:
     name: deploy catalog (staging)
     environment: staging
     runs-on: ubuntu-latest
+    concurrency: catalog-staging-deployment
     strategy:
       fail-fast: false
       matrix:
@@ -163,6 +164,7 @@ jobs:
     name: deploy catalog (prod)
     environment: prod
     runs-on: ubuntu-latest
+    concurrency: catalog-prod-deployment
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -10,6 +10,7 @@ jobs:
     name: restart (staging)
     environment: staging
     runs-on: ubuntu-latest
+    concurrency: catalog-staging-deployment
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -69,6 +70,7 @@ jobs:
     name: restart (prod)
     environment: prod
     runs-on: ubuntu-latest
+    concurrency: catalog-prod-deployment
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
We are consistently getting `Deployment has been superseded`, see [recent deployment](https://github.com/GSA/catalog.data.gov/actions/runs/3299374769/jobs/5442701933). [GitHub Actions concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idconcurrency) should keep deployment and restart jobs from running at the same time and causing this problem...
I thought we had already fixed this, but apparently not...