### PR TITLE
Update URL for staging and dev

### DIFF
--- a/vars.development.yml
+++ b/vars.development.yml
@@ -15,7 +15,7 @@ gather_memory_quota: 1G
 new_relic_monitor_mode: false
 
 # use CDN domain for route-public if available, otherwise use route-external 
-route-public: d2jqk88ququ1n9.cloudfront.net
+route-public: d1arsxiohwi85v.cloudfront.net
 route-external: catalog-dev-datagov.app.cloud.gov
 route-internal: catalog-dev-datagov.apps.internal
 route-external-admin: catalog-dev-admin-datagov.app.cloud.gov

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -15,7 +15,7 @@ gather_memory_quota: 3G
 new_relic_monitor_mode: true
 
 # use CDN domain for route-public if available, otherwise use route-external 
-route-public: d1u59lafwydg4a.cloudfront.net
+route-public: dslreta8swgrd.cloudfront.net
 route-external: catalog-stage-datagov.app.cloud.gov
 route-internal: catalog-stage-datagov.apps.internal
 route-external-admin: catalog-stage-admin-datagov.app.cloud.gov


### PR DESCRIPTION
In trying to clear the cache for staging, it was discovered that these do not coincide with the GSA-OPPPROD account. If you use the ones detailed in oppprod, then you're redirected to the ones specified in the catalog config (that are changed here). My understanding is that these that are being replaced are created outside the GSA environment... These should be the correct ones.