### PR TITLE
added file and route for reg

### DIFF
--- a/proxy/nginx-common.conf
+++ b/proxy/nginx-common.conf
@@ -58,6 +58,11 @@ location = /robots.txt {
     root ./public;
 }
 
+# for google search console registration
+location = /googlef06939d03de4c107.html {
+    root ./public;
+}
+
 error_page 500 502 503 504 /500.html;
 location = /500.html {
   root ./public;

--- a/proxy/public/googlef06939d03de4c107.html
+++ b/proxy/public/googlef06939d03de4c107.html
@@ -1,0 +1,1 @@
+google-site-verification: googlef06939d03de4c107.html


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3648

To register catalog.data.gov to us, google needs to have this file available. Once registered, we should be able to view/trigger sitemap crawls. 