### PR TITLE
proxypass for sitemap

### DIFF
--- a/proxy/.profile
+++ b/proxy/.profile
@@ -38,5 +38,3 @@ S3_URL=https://$(vcap_get_service s3 .credentials.endpoint)
 S3_BUCKET=$(vcap_get_service s3 .credentials.bucket)
 SITEMAP_URL="$S3_URL/$S3_BUCKET/sitemap.xml"
 export SITEMAP_URL
-# replaces value in robots.txt, maybe update this to nice url?
-sed -i "s,SITEMAP_URL,${SITEMAP_URL}," ./public/robots.txt

--- a/proxy/.profile
+++ b/proxy/.profile
@@ -37,5 +37,6 @@ sed -i "s/auth_configured/${BASIC_AUTH_ENABLED}/" ./nginx.conf
 S3_URL=https://$(vcap_get_service s3 .credentials.endpoint)
 S3_BUCKET=$(vcap_get_service s3 .credentials.bucket)
 SITEMAP_URL="$S3_URL/$S3_BUCKET/sitemap.xml"
+export SITEMAP_URL
 # replaces value in robots.txt, maybe update this to nice url?
 sed -i "s,SITEMAP_URL,${SITEMAP_URL}," ./public/robots.txt

--- a/proxy/nginx-common.conf
+++ b/proxy/nginx-common.conf
@@ -63,6 +63,10 @@ location = /googlef06939d03de4c107.html {
     root ./public;
 }
 
+location = /sitemap.xml {
+    proxy_pass {{ENV "S3_URL"}}/sitemap.xml
+}
+
 error_page 500 502 503 504 /500.html;
 location = /500.html {
   root ./public;

--- a/proxy/public/robots.txt
+++ b/proxy/public/robots.txt
@@ -6,4 +6,4 @@ Disallow: /api/
 Crawl-Delay: 10
 
 # sitemap url should get replaced by proxy .profile
-Sitemap: SITEMAP_URL
+Sitemap: https://catalog.data.gov/sitemap.xml


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3648

Some shellcheck appeasement, but mostly added proxy pass for `/sitemap.xml` so it can be added to the Google Search Console.