### PR TITLE
bump datagovtheme version to 0.1.14

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -10,7 +10,7 @@ git+https://github.com/keitaroinc/ckanext-saml2auth.git@main#egg=ckanext-saml2au
 -e git+https://github.com/ckan/ckanext-report.git@master#egg=ckanext-report
 
 ckanext-datagovcatalog>=0.0.3
-ckanext-datagovtheme>=0.1.11
+ckanext-datagovtheme>=0.1.14
 ckanext-datajson>=0.1.6
 ckanext-envvars>=0.0.2
 ckanext-geodatagov>=0.1.15

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -11,7 +11,7 @@ chardet==3.0.4
 ckan @ git+https://github.com/ckan/ckan.git@65af260bef26ea99981597f872d39da0a3f4f3f9
 -e git+https://github.com/ckan/ckanext-archiver.git@c96e3c81bfc430cdb0372f3307c7abd4109a80f1#egg=ckanext_archiver
 ckanext-datagovcatalog==0.0.5
-ckanext-datagovtheme==0.1.12
+ckanext-datagovtheme==0.1.14
 ckanext-datajson==0.1.6
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@6fb70aaa00ca9e790535e12f96c50f5c39017f6e
 ckanext-envvars==0.0.2


### PR DESCRIPTION
# Pull Request

related to https://github.com/GSA/data.gov/issues/4006

# About

bump datagovtheme version to 0.1.14 which fixed issue for the broken search link.  