### PR TITLE
fix envvar name

### DIFF
--- a/proxy/nginx-common.conf
+++ b/proxy/nginx-common.conf
@@ -64,7 +64,7 @@ location = /googlef06939d03de4c107.html {
 }
 
 location = /sitemap.xml {
-    proxy_pass {{ENV "S3_URL"}}/sitemap.xml
+    proxy_pass {{ENV "SITEMAP_URL"}}/sitemap.xml
 }
 
 error_page 500 502 503 504 /500.html;


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3648

In [PR 622](https://github.com/GSA/catalog.data.gov/pull/622/files), I exported the sitemap url as `SITEMAP_URL` and had nginx look for it as `S3_URL`. Oops. 