### PR TITLE
change sitemap action to run on gather

### DIFF
--- a/.github/workflows/s3-to-sitemap.yml
+++ b/.github/workflows/s3-to-sitemap.yml
@@ -18,7 +18,7 @@ jobs:
         uses: cloud-gov/cg-cli-tools@main
         with:
           command: >
-            cf run-task catalog-admin
+            cf run-task catalog-gather
             --command "ckan geodatagov sitemap-to-s3"
             --name sitemap
             -m 3G -k 3G


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3648

Changing which app the sitemap action is run on, as per [suggestion](https://github.com/GSA/ckanext-geodatagov/pull/232#issuecomment-1299065568). 