### PR TITLE
Set http_proxy too!

### DIFF
--- a/.profile
+++ b/.profile
@@ -14,6 +14,7 @@ if [ -z ${proxy_url+x} ]; then
   echo "Egress proxy is not connected."
 else
   export https_proxy=$proxy_url
+  export http_proxy=$proxy_url
 fi
 
 echo "java setup"


### PR DESCRIPTION
Related to 
- Conversation with @FuhuXia 

I don't know if this will work because I think the `egress-proxy` only supports https connections, but it might be able to proxy non-tls traffic too?  Does someone else know? @robert-bryson @btylerburton @jbrown-xentity @FuhuXia @Jin-Sun-tts 