### PR TITLE
simplejson 3.18.0

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -96,7 +96,7 @@ s3transfer==0.6.0
 setuptools==65.5.1
 Shapely==1.8.5.post1
 shutilwhich==1.1.0
-simplejson==3.10.0
+simplejson==3.18.0 # ckan 2.9.5 requires 3.10.0 only
 six==1.16.0
 SQLAlchemy==1.3.5
 sqlparse==0.4.2


### PR DESCRIPTION
Started to see errors [during deployment](https://github.com/GSA/catalog.data.gov/actions/runs/3534129279/jobs/5930637727) with `3.10.0`. Try `3.18.0`

```
Collecting simplejson==3.10.0
  File was already downloaded /home/vcap/app/vendor/simplejson-3.10.0.tar.gz
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-download-johd7kki/simplejson_7dfec9d93cdb48f1b5829c51ae9cc717/setup.py", line 111, in <module>
          run_setup(not IS_PYPY)
        File "/tmp/pip-download-johd7kki/simplejson_7dfec9d93cdb48f1b5829c51ae9cc717/setup.py", line 96, in run_setup
          setup(
        File "/usr/local/lib/python3.8/dist-packages/setuptools/__init__.py", line 87, in setup
          return distutils.core.setup(**attrs)
        File "/usr/local/lib/python3.8/dist-packages/setuptools/_distutils/core.py", line 147, in setup
          _setup_distribution = dist = klass(attrs)
        File "/usr/local/lib/python3.8/dist-packages/setuptools/dist.py", line 475, in __init__
          _Distribution.__init__(
        File "/usr/local/lib/python3.8/dist-packages/setuptools/_distutils/dist.py", line 258, in __init__
          getattr(self.metadata, "set_" + key)(val)
        File "/usr/local/lib/python3.8/dist-packages/setuptools/_distutils/dist.py", line 1242, in set_classifiers
          self.classifiers = _ensure_list(value, 'classifiers')
        File "/usr/local/lib/python3.8/dist-packages/setuptools/_distutils/dist.py", line 48, in _ensure_list
          log.warning(msg)
      AttributeError: module 'distutils.log' has no attribute 'warning'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.
```