### PR TITLE
Revert "Pin pysaml2 to working version"

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -17,8 +17,6 @@ ckanext-geodatagov>=0.1.15
 ckanext-googleanalyticsbasic
 ckanext-metrics-dashboard
 
-# Pin for saml2auth to work
-pysaml2==7.0.1
 
 # ckanext-harvest dependencies
 ckantoolkit>=0.0.7

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -74,7 +74,7 @@ PyJWT==2.4.0
 pyOpenSSL==22.1.0
 pyparsing==3.0.9
 pyproj==2.6.1
-pysaml2==7.0.1
+pysaml2==7.2.1
 pysolr==3.6.0
 python-dateutil==2.8.2
 python-editor==1.0.4


### PR DESCRIPTION
Reverts 
- GSA/catalog.data.gov#553

Related to
- https://github.com/GSA/data.gov/issues/3980

This is testing since we are no longer pinned to Python 3.7, this might work.