### PR TITLE
bump geodatagov

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -15,7 +15,7 @@ ckanext-datagovtheme==0.1.17
 ckanext-datajson==0.1.10
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@618928be5a211babafc45103a72b6aab4642e964
 ckanext-envvars==0.0.2
-ckanext-geodatagov==0.1.17
+ckanext-geodatagov==0.1.18
 ckanext-googleanalyticsbasic==0.2.0
 -e git+https://github.com/ckan/ckanext-harvest.git@2e5ac42f3ba58dd4bcb1e69a783e155828ff4b89#egg=ckanext_harvest
 ckanext-metrics-dashboard==0.1.5


### PR DESCRIPTION
Relate to https://github.com/GSA/data.gov/issues/4061

Pulling in changes from https://github.com/GSA/ckanext-geodatagov/pull/235. Please do not merge until [this finishes](https://github.com/GSA/ckanext-geodatagov/actions/runs/3707430732) and Pypi has the [new `0.1.18`](https://pypi.org/project/ckanext-geodatagov/#history)