### PR TITLE
Fix: move fail-fast parameter under strategy

### DIFF
--- a/.github/workflows/check-stuck-harvest-jobs-automated.yml
+++ b/.github/workflows/check-stuck-harvest-jobs-automated.yml
@@ -8,8 +8,8 @@ on:   # yamllint disable-line rule:truthy
 jobs:
   check-stuck-jobs:
     name: Check Stuck Harvest Jobs On Schedule
-    fail-fast: false
     strategy:
+      fail-fast: false
       matrix:
         environ: [development, staging, prod]
         include:


### PR DESCRIPTION
fail-fast parameter should be under strategy, moved to the right location.