### PR TITLE
Change harvest timeout to 72 hours and turn on harvest run on staging

### DIFF
--- a/.github/workflows/run-harvest-check.yml
+++ b/.github/workflows/run-harvest-check.yml
@@ -14,22 +14,22 @@ jobs:
     steps:
       - name: Pausing Harvesters most likely for re-indexing
         run: echo "hi"
-  # harvest-run-staging:
-  #   name: harvest-run (staging)
-  #   environment: staging
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: harvest-run
-  #       # pinned to cf7 until --wait is available for run-task on cf8...
-  #       uses: cloud-gov/cg-cli-tools@main
-  #       with:
-  #         command: >
-  #           cf run-task catalog-admin --command 'ckan harvester run'
-  #           --name 'harvester-check-completed (CI)' -k 2G -k 1500M
-  #         cf_org: gsa-datagov
-  #         cf_space: staging
-  #         cf_username: ${{secrets.CF_SERVICE_USER}}
-  #         cf_password: ${{secrets.CF_SERVICE_AUTH}}
+  harvest-run-staging:
+    name: harvest-run (staging)
+    environment: staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: harvest-run
+        # pinned to cf7 until --wait is available for run-task on cf8...
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            cf run-task catalog-admin --command 'ckan harvester run'
+            --name 'harvester-check-completed (CI)' -k 2G -k 1500M
+          cf_org: gsa-datagov
+          cf_space: staging
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
   harvest-run-prod:
     name: harvest-run (prod)
     environment: prod

--- a/ckan/setup/ckan.ini
+++ b/ckan/setup/ckan.ini
@@ -230,8 +230,8 @@ ckanext.spatial.search_backend = solr
 # ckanext-harvest will use ckan.redis.url if redis configuration
 # is not specified here.
 
-# Mark as finished Jobs in 'Running' status after x minutes (1440 min = 24 hours)
-ckan.harvest.timeout = 1440
+# Mark as finished Jobs in 'Running' status after x minutes (4320 min = 72 hours)
+ckan.harvest.timeout = 4320
 
 # define the time frame in days to clean the harvest logs
 ckan.harvest.log_timeframe = 180


### PR DESCRIPTION
# Pull Request

[Set up a task to find stuck harvest jobs#4058](https://github.com/GSA/data.gov/issues/4058)

## About

Changed ckan.harvest.timeout from 24 hours to 72 hours.
Turned on the harvester run on staging.