### PR TITLE
In case the repo default is not main, use $default-branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,7 @@ name: publish & deploy
 
 on:   # yamllint disable-line rule:truthy
   push:
-    branches:
-      - main
+    branches: [$default-branch]
 
 jobs:
   ghcr_publish:


### PR DESCRIPTION
Not a big change, but probably a good habit to get into as we start using more templates.