### PR TITLE
backing out change to $deault-branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,8 @@ name: publish & deploy
 
 on:   # yamllint disable-line rule:truthy
   push:
-    branches: [$default-branch]
+    branches:
+      - main
 
 jobs:
   ghcr_publish:


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/4158

Reverts https://github.com/GSA/catalog.data.gov/pull/739

I was too hasty with this. The `$deafult-branch` tag is specific to workflow templates. See [this](https://github.com/orgs/community/discussions/26597) and [this](https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow)(the note for step 3). 