### PR TITLE
No need to check harvest jobs on dev

### DIFF
--- a/.github/workflows/db-solr-sync-automated.yml
+++ b/.github/workflows/db-solr-sync-automated.yml
@@ -10,10 +10,8 @@ jobs:
     name: DB Solr Sync On Schedule
     strategy:
       matrix:
-        environ: [development, staging, prod]
+        environ: [staging, prod]
         include:
-          - environ: development
-            ram: 1G
           - environ: staging
             ram: 3G
           - environ: prod


### PR DESCRIPTION
Related to
- #750 

Harvest jobs are not managed on development space, no need to raise an alarm for development space.