### PR TITLE
update geodatagov version

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -13,7 +13,7 @@ ckanext-datagovcatalog>=0.0.3
 ckanext-datagovtheme>=0.1.19
 ckanext-datajson>=0.1.12
 ckanext-envvars>=0.0.2
-ckanext-geodatagov>=0.1.22
+ckanext-geodatagov>=0.1.23
 ckanext-googleanalyticsbasic
 ckanext-metrics-dashboard
 

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -15,7 +15,7 @@ ckanext-datagovtheme==0.1.19
 ckanext-datajson==0.1.12
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@618928be5a211babafc45103a72b6aab4642e964
 ckanext-envvars==0.0.2
-ckanext-geodatagov==0.1.22
+ckanext-geodatagov==0.1.23
 ckanext-googleanalyticsbasic==0.2.0
 -e git+https://github.com/ckan/ckanext-harvest.git@10e50a709b8ff472d7e4c7ffc880513f5cf1ef7f#egg=ckanext_harvest
 ckanext-metrics-dashboard==0.1.5


### PR DESCRIPTION
Update the geodatagov version with the latest changes in check-stuck-job command output

Related to [[Add more information for the stuck harvest job report#4184](https://github.com/GSA/data.gov/issues/4184)]

Changes: https://github.com/GSA/ckanext-geodatagov/pull/241