### PR TITLE
Don't check stuck  jobs on development

### DIFF
--- a/.github/workflows/check-stuck-harvest-jobs-automated.yml
+++ b/.github/workflows/check-stuck-harvest-jobs-automated.yml
@@ -11,10 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environ: [development, staging, prod]
+        environ: [staging, prod]
         include:
-          - environ: development
-            ram: 1G
           - environ: staging
             ram: 3G
           - environ: prod


### PR DESCRIPTION
I know I've made this change in the past, not sure how it got reverted.. 😕