### PR TITLE
dont use ckan storage in our ephemeral apps

### DIFF
--- a/.profile
+++ b/.profile
@@ -87,7 +87,6 @@ export CKAN_SQLALCHEMY_URL=$(vcap_get_service db .credentials.uri)
 export CKAN___SQLALCHEMY__POOL_SIZE=250
 export CKAN___SQLALCHEMY__MAX_OVERFLOW=500
 
-export CKAN_STORAGE_PATH=${SHARED_DIR}/files
 export CKAN___BEAKER__SESSION__SECRET=$(vcap_get_service secrets .credentials.CKAN___BEAKER__SESSION__SECRET)
 export CKAN___BEAKER__SESSION__URL=${CKAN_SQLALCHEMY_URL}
 export CKANEXT__SAML2AUTH__KEY_FILE_PATH=${CONFIG_DIR}/saml2_key.pem
@@ -138,7 +137,6 @@ export CKAN_SOLR_URL=$CKAN_SOLR_BASE_URL/solr/$SOLR_COLLECTION
 export NO_PROXY=$NO_PROXY,$CKAN_SOLR_URL
 
 # Write out any files and directories
-mkdir -p $CKAN_STORAGE_PATH
 echo "$SAML2_PRIVATE_KEY" | base64 --decode > $CKANEXT__SAML2AUTH__KEY_FILE_PATH
 echo "$SAML2_CERTIFICATE" > $CKANEXT__SAML2AUTH__CERT_FILE_PATH
 

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -29,8 +29,7 @@ ENV SRC_DIR=/srv/app/src
 ENV SRC_EXTENSIONS_DIR=/srv/app/src_extensions
 ENV CKAN_INI=${APP_DIR}/ckan.ini
 ENV PIP_SRC=${SRC_DIR}
-ENV CKAN_STORAGE_PATH=/var/lib/ckan
-RUN mkdir -p $CKAN_STORAGE_PATH $APP_DIR $SRC_EXTENSIONS_DIR
+RUN mkdir -p $APP_DIR $SRC_EXTENSIONS_DIR
 
 # CKAN Setup Files
 # Our production ckan.ini messes with local login

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       - "0.0.0.0:${PORT}:${PORT}"
     volumes:
       - ./src:/srv/app/src_extensions
-      - ckan_storage:/var/lib/ckan
       - ./ckan/setup/prerun.py:/srv/app/prerun.py
       - ./ckan/setup/ckan_setup.sh:/srv/app/ckan_setup.sh
       - ./ckan/docker-entrypoint.d/:/docker-entrypoint.d/
@@ -53,6 +52,5 @@ services:
       - ./tests/nginx.conf:/etc/nginx/conf.d/default.conf
 
 volumes:
-  ckan_storage:
   pg_data:
   solr_data:


### PR DESCRIPTION
if `ckan_storage` is enabled, it allows user to upload logo image in organization creation page. We do not want to support this since all uploaded files will be gone after next restart. 

![image](https://user-images.githubusercontent.com/1392461/217603583-da7a444e-e807-4392-9b43-4730de4d6a24.png)
