### PR TITLE
different solr/service-config.json for spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Create the Redis service for cache
 
 Create the SOLR service for data search
 
-    $ cf create-service solr-cloud base ${app_name}-solr -c solr/service-config.json -b ssb-solr-gsa-datagov-development
+    $ cf create-service solr-cloud base ${app_name}-solr -c solr/service-config-${space}.json -b ssb-solr-gsa-datagov-${space}
 
 Create the secrets service to store secret environment variables. See
 [Secrets](#secrets) below.

--- a/create-cloudgov-services.sh
+++ b/create-cloudgov-services.sh
@@ -19,9 +19,9 @@ else
 fi
 
 # TODO: update if and when the service broker reverts to `ssb-solr-gsa-datagov-<space>`
-cf service "${app_name}-solr"      > /dev/null 2>&1 || cf create-service solr-on-ecs base "${app_name}-solr" -c solr/service-config.json -b "ssb-solrcloud-gsa-datagov-${space}" --wait&
+cf service "${app_name}-solr"      > /dev/null 2>&1 || cf create-service solr-on-ecs base "${app_name}-solr" -c solr/service-config-${space}.json -b "ssb-solrcloud-gsa-datagov-${space}" --wait&
 
-cf service "${app_name}-smtp"      > /dev/null 2>&1 || cf create-service datagov-smtp base "${app_name}-smtp" -c smtp/service-config.json -b "ssb-smtp-gsa-datagov-${space}" --wait&
+cf service "${app_name}-smtp"      > /dev/null 2>&1 || cf create-service datagov-smtp base "${app_name}-smtp" -c smtp/service-config-${space}.json -b "ssb-smtp-gsa-datagov-${space}" --wait&
 
 # Wait until all the services are ready
 wait

--- a/solr/service-config-development.json
+++ b/solr/service-config-development.json
@@ -1,7 +1,7 @@
 {
     "solrImageRepo": "ghcr.io/gsa/catalog.data.gov.solr",
     "solrImageTag": "8-stunnel-root",
-    "solrFollowerCount": 2,
+    "solrFollowerCount": 1,
     "solrMem": 28672,
     "solrCpu": 4096,
     "solrFollowerMem": 28672,
@@ -9,9 +9,8 @@
     "setupFollowerLink": "https://raw.githubusercontent.com/GSA/catalog.data.gov/main/solr/solr_setup.sh",
     "disableEfs": false,
     "disableEfsFollower": false,
-    "efsProvisionedThroughput": 25,
-    "efsProvisionedThroughputFollower": 75,
+    "efsProvisionedThroughput": 5,
+    "efsProvisionedThroughputFollower": 5,
     "efsPerformanceMode": "maxIO",
-    "slackNotification": true,
-    "emailNotification": "datagovhelp@gsa.gov"
+    "slackNotification": false
 }

--- a/solr/service-config-prod.json
+++ b/solr/service-config-prod.json
@@ -1,0 +1,17 @@
+{
+    "solrImageRepo": "ghcr.io/gsa/catalog.data.gov.solr",
+    "solrImageTag": "8-stunnel-root",
+    "solrFollowerCount": 3,
+    "solrMem": 28672,
+    "solrCpu": 4096,
+    "solrFollowerMem": 28672,
+    "solrFollowerCpu": 4096,
+    "setupFollowerLink": "https://raw.githubusercontent.com/GSA/catalog.data.gov/main/solr/solr_setup.sh",
+    "disableEfs": false,
+    "disableEfsFollower": false,
+    "efsProvisionedThroughput": 25,
+    "efsProvisionedThroughputFollower": 75,
+    "efsPerformanceMode": "maxIO",
+    "slackNotification": true,
+    "emailNotification": "datagovhelp@gsa.gov"
+}

--- a/solr/service-config-staging.json
+++ b/solr/service-config-staging.json
@@ -1,0 +1,16 @@
+{
+    "solrImageRepo": "ghcr.io/gsa/catalog.data.gov.solr",
+    "solrImageTag": "8-stunnel-root",
+    "solrFollowerCount": 2,
+    "solrMem": 28672,
+    "solrCpu": 4096,
+    "solrFollowerMem": 28672,
+    "solrFollowerCpu": 4096,
+    "setupFollowerLink": "https://raw.githubusercontent.com/GSA/catalog.data.gov/main/solr/solr_setup.sh",
+    "disableEfs": false,
+    "disableEfsFollower": false,
+    "efsProvisionedThroughput": 5,
+    "efsProvisionedThroughputFollower": 5,
+    "efsPerformanceMode": "maxIO",
+    "slackNotification": false
+}


### PR DESCRIPTION
We have been using the same config file but did some manual tweak on the AWS console so that each space uses different solr config. Now it is time make the config file space-specific. 