### PR TITLE
disable automated db-solr-sync

### DIFF
--- a/.github/workflows/db-solr-sync-automated.yml
+++ b/.github/workflows/db-solr-sync-automated.yml
@@ -10,11 +10,9 @@ jobs:
     name: DB Solr Sync On Schedule
     strategy:
       matrix:
-        environ: [staging, prod]
+        environ: [staging]
         include:
           - environ: staging
-            ram: 3G
-          - environ: prod
             ram: 3G
     runs-on: ubuntu-latest
     environment: ${{matrix.environ}}


### PR DESCRIPTION
disable it for now so that it does not cause conflict with the initial manual db-solr-sync job, which may last for quite a few hours.