### PR TITLE
Revert "disable auto db-solr-sync on prod"

### DIFF
--- a/.github/workflows/db-solr-sync-automated.yml
+++ b/.github/workflows/db-solr-sync-automated.yml
@@ -10,9 +10,11 @@ jobs:
     name: DB Solr Sync On Schedule
     strategy:
       matrix:
-        environ: [staging]
+        environ: [staging, prod]
         include:
           - environ: staging
+            ram: 3G
+          - environ: prod
             ram: 3G
     runs-on: ubuntu-latest
     environment: ${{matrix.environ}}


### PR DESCRIPTION
This reverts commit 3eb178fb878feb0bf14c3ab29fc2334cb181afc1.

Turn the db-solr-sync back on for prod.