### PR TITLE
Split harvesting into separate workflow

### DIFF
--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -1,11 +1,10 @@
 ---
-name: 4 - Automated CKAN Jobs
+name: 4 - Automated CKAN Jobs (minus Harvesting)
 
 on:   # yamllint disable-line rule:truthy
   schedule:
     - cron: '30 7 * * *'       # Tracking Update -- every day at 7:30am UTC
     - cron: '0 3 * * *'        # S3 Sitemap Update -- every day at 3am UTC
-    - cron: '4/15 * * * *'     # Harvester Check -- every 15 mins
     - cron: '0 4 * * *'        # DB-Solr-Sync -- every day at 4am UTC
     - cron: '0 5 * * *'        # Check Stuck Jobs -- every day at 5am UTC
 
@@ -18,7 +17,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        schedule: ['30 7 * * *', '0 3 * * *', '11/15 * * * *', '0 4 * * *', '0 5 * * *']   # yamllint disable-line rule:line-length
+        schedule: ['30 7 * * *', '0 3 * * *', '0 4 * * *', '0 5 * * *']   # yamllint disable-line rule:line-length
         environ: [development, staging, prod]
         include:
           # Default app to run tasks on
@@ -30,8 +29,6 @@ jobs:
           # Attach commands to schedule
           - schedule: '30 7 * * *'
             command: "ckan geodatagov tracking-update"
-          - schedule: '11/15 * * * *'
-            command: "ckan harvester run"
           - schedule: '0 4 * * *'
             command: "ckan geodatagov db-solr-sync"
           - schedule: '0 5 * * *'
@@ -41,9 +38,6 @@ jobs:
           # Run sitemap-to-s3 on catalog-gather
           - schedule: '0 3 * * *'
             app: catalog-gather
-          # Don't monitor 'harvester run'
-          - schedule: '11/15 * * * *'
-            monitor: false
           # Don't monitor 'sitemap-to-s3'
           - schedule: '0 3 * * *'
             monitor: false

--- a/.github/workflows/ckan_harvester.yml
+++ b/.github/workflows/ckan_harvester.yml
@@ -1,0 +1,48 @@
+---
+name: 4b - CKAN Harvesting
+
+on:   # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '4/15 * * * *'     # Harvester Check -- every 15 mins
+
+jobs:
+  ckan-auto-command:
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        environ: [development, staging, prod]
+        include:
+          - app: catalog-admin
+          - command: "ckan harvester run"
+          # Adjust RAM per space
+          - environ: development
+            ram: 1G
+          - environ: staging
+            ram: 3G
+          - environ: prod
+            ram: 3G
+    name: ${{ matrix.command }} - ${{matrix.environ}}
+    runs-on: ubuntu-latest
+    environment: ${{matrix.environ}}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Set Unique Command Name
+        # yamllint disable rule:line-length
+        run: |
+          INSTANCE_NAME="$(echo ${{ matrix.command }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT})"
+          echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
+          # yamllint enable rule:line-length
+      - name: ${{ matrix.command }}
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            cf run-task ${{ matrix.app }}
+            --command "${{ matrix.command }}"
+            --name "$INSTANCE_NAME"
+            -m ${{ matrix.ram }} -k 2G
+          cf_org: gsa-datagov
+          cf_space: ${{ matrix.environ }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}


### PR DESCRIPTION
Related to
- #822 

When everything was combined, it was only running things on the harvesting schedule and the other schedules were never being honored... I think this is because the total time for the automated jobs (when consolidated) was too long (>8 mins) and it was probably messing with the scheduling conditions..?