### PR TITLE
Optimize Automated CKAN Command Management

### DIFF
--- a/.github/db-solr-sync-info.md
+++ b/.github/db-solr-sync-info.md
@@ -1,5 +1,5 @@
 ---
-title: 📌 DB Solr Sync Auditing Issue 
+title: 📌 DB Solr Sync Auditing Log
 labels: bug
 ---
 

--- a/.github/db-solr-sync-info.md
+++ b/.github/db-solr-sync-info.md
@@ -1,0 +1,16 @@
+---
+title: 📌 DB Solr Sync Auditing Issue 
+labels: bug
+---
+
+Workflow with Issue: {{ workflow }}
+Job Failed: {{ env.GITHUB_JOB }}
+CKAN Command (in question): {{ env.COMMAND }}
+CKAN Command Schedule: {{ env.SCHEDULE }}
+Cloud.gov Environment: {{ env.ENVIRONMENT }}
+Total Execution Time: {{ env.EXEC_TIME }}
+
+Last Commit: {{ env.LAST_COMMIT }}
+Number of times run: {{ env.GITHUB_ATTEMPTS }}
+Last run by: {{ env.LAST_RUN_BY }}
+Github Action Run: https://github.com/GSA/catalog.data.gov/actions/runs/{{ env.RUN_ID }}

--- a/.github/tracking-update-info.md
+++ b/.github/tracking-update-info.md
@@ -1,5 +1,5 @@
 ---
-title: 📌 Tracking Update Auditing Issue 
+title: 📌 Tracking Update Auditing Log
 labels: bug
 ---
 

--- a/.github/tracking-update-info.md
+++ b/.github/tracking-update-info.md
@@ -1,0 +1,16 @@
+---
+title: 📌 Tracking Update Auditing Issue 
+labels: bug
+---
+
+Workflow with Issue: {{ workflow }}
+Job Failed: {{ env.GITHUB_JOB }}
+CKAN Command (in question): {{ env.COMMAND }}
+CKAN Command Schedule: {{ env.SCHEDULE }}
+Cloud.gov Environment: {{ env.ENVIRONMENT }}
+Total Execution Time: {{ env.EXEC_TIME }}
+
+Last Commit: {{ env.LAST_COMMIT }}
+Number of times run: {{ env.GITHUB_ATTEMPTS }}
+Last run by: {{ env.LAST_RUN_BY }}
+Github Action Run: https://github.com/GSA/catalog.data.gov/actions/runs/{{ env.RUN_ID }}

--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -66,8 +66,10 @@ jobs:
             environ: development
           - schedule: '0 3 * * *'
             environ: staging
-          # Don't run 'db-solr-sync' on development
+          # Don't run 'db-solr-sync' + 'check-stuck-jobs' on development
           - schedule: '0 5 * * *'
+            environ: development
+          - schedule: '0 4 * * *'
             environ: development
     name: ${{ matrix.command }} - ${{matrix.environ}}
     runs-on: ubuntu-latest

--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -11,6 +11,12 @@ on:   # yamllint disable-line rule:truthy
 
 env:
   ERROR: false
+  # Make sure 'schedule-cron' matches these varaibles.
+  SCHEDULE_TRACKING: '30 7 * * *'
+  SCHEDULE_SITEMAP: '0 3 * * *'
+  SCHEDULE_HARVESTING: '4/15 * * * *'
+  SCHEDULE_STUCK_JOBS: '0 4 * * *'
+  SCHEDULE_DBSOLR_SYNC: '0 5 * * *'
 
 jobs:
   ckan-auto-command:
@@ -18,7 +24,10 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        schedule: ['30 7 * * *', '0 3 * * *', '4/15 * * * *', '0 4 * * *', '0 5 * * *']   # yamllint disable-line rule:line-length
+        schedule: [
+          $SCHEDULE_TRACKING, $SCHEDULE_SITEMAP, $SCHEDULE_HARVESTING,
+          $SCHEDULE_STUCK_JOBS, $SCHEDULE_DBSOLR_SYNC
+        ]
         environ: [development, staging, prod]
         include:
           # Default app to run tasks on
@@ -28,30 +37,30 @@ jobs:
           # Default monitor everything
           - monitor: true
           # Attach commands to schedule
-          - schedule: '30 7 * * *'
+          - schedule: $SCHEDULE_TRACKING
             command: "ckan geodatagov tracking-update"
-          - schedule: '4/15 * * * *'
+          - schedule: $SCHEDULE_HARVESTING
             command: "ckan harvester run"
-          - schedule: '0 4 * * *'
+          - schedule: $SCHEDULE_DBSOLR_SYNC
             command: "ckan geodatagov db-solr-sync"
-          - schedule: '0 5 * * *'
+          - schedule: $SCHEDULE_STUCK_JOBS
             command: "ckan geodatagov check-stuck-jobs"
-          - schedule: '0 3 * * *'
+          - schedule: $SCHEDULE_SITEMAP
             command: "ckan geodatagov sitemap-to-s3"
           # Run sitemap-to-s3 on catalog-gather
-          - schedule: '0 3 * * *'
+          - schedule: $SCHEDULE_SITEMAP
             app: catalog-gather
           # Don't monitor 'harvester run'
-          - schedule: '4/15 * * * *'
+          - schedule: $SCHEDULE_HARVESTING
             monitor: false
           # Don't monitor 'sitemap-to-s3'
-          - schedule: '0 3 * * *'
+          - schedule: $SCHEDULE_SITEMAP
             monitor: false
           # If tracking update takes longer than 210 mins, make an issue
-          - schedule: '30 7 * * *'
+          - schedule: $SCHEDULE_TRACKING
             error_seconds: 12600
           # If db solr sync takes longer than 30 mins, make an issue
-          - schedule: '0 4 * * *'
+          - schedule: $SCHEDULE_DBSOLR_SYNC
             error_seconds: 1800
           # Adjust RAM per space
           - environ: development
@@ -62,14 +71,14 @@ jobs:
             ram: 3G
         exclude:
           # Don't run 'sitemap-to-s3' on development/staging
-          - schedule: '0 3 * * *'
+          - schedule: $SCHEDULE_SITEMAP
             environ: development
-          - schedule: '0 3 * * *'
+          - schedule: $SCHEDULE_SITEMAP
             environ: staging
           # Don't run 'db-solr-sync' + 'check-stuck-jobs' on development
-          - schedule: '0 5 * * *'
+          - schedule: $SCHEDULE_DBSOLR_SYNC
             environ: development
-          - schedule: '0 4 * * *'
+          - schedule: $SCHEDULE_STUCK_JOBS
             environ: development
     name: ${{ matrix.command }} - ${{matrix.environ}}
     runs-on: ubuntu-latest

--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -5,7 +5,7 @@ on:   # yamllint disable-line rule:truthy
   schedule:
     - cron: '30 7 * * *'       # Tracking Update -- every day at 2:30am EST
     - cron: '0 2 * * *'        # S3 Sitemap Update -- every day at 7pm EST
-    - cron: '4/15 5-23 * * *'  # Harvester Check -- every 15 mins between 12am and 6pm EST   # yamllint disable-line rule:line-length
+    - cron: '4/15 5-23 * * *'  # Harvester Check -- every 15 mins between 12am and 6pm EST
     - cron: '0 3 * * *'        # DB-Solr-Sync -- every day at 10pm EST
     - cron: '0 4 * * *'        # Check Stuck Jobs -- every day at 11pm EST
 

--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -3,20 +3,20 @@ name: 4 - Automated CKAN Jobs
 
 on:   # yamllint disable-line rule:truthy
   schedule:
-    - cron: '30 7 * * *'       # Tracking Update -- every day at 7:30am UTC
-    - cron: '0 3 * * *'        # S3 Sitemap Update -- every day at 3am UTC
-    - cron: '4/15 * * * *'     # Harvester Check -- every 15 mins
-    - cron: '0 4 * * *'        # DB-Solr-Sync -- every day at 4am UTC
-    - cron: '0 5 * * *'        # Check Stuck Jobs -- every day at 5am UTC
+    - cron: '30 7 * * *'       # Tracking Update -- every day at 2:30am EST
+    - cron: '0 2 * * *'        # S3 Sitemap Update -- every day at 7pm EST
+    - cron: '4/15 5-23 * * *'  # Harvester Check -- every 15 mins between 12am and 6pm EST
+    - cron: '0 3 * * *'        # DB-Solr-Sync -- every day at 10pm EST
+    - cron: '0 4 * * *'        # Check Stuck Jobs -- every day at 11pm EST
 
 env:
   ERROR: false
   # Make sure 'schedule-cron' matches these varaibles.
   SCHEDULE_TRACKING: '30 7 * * *'
-  SCHEDULE_SITEMAP: '0 3 * * *'
-  SCHEDULE_HARVESTING: '4/15 * * * *'
-  SCHEDULE_STUCK_JOBS: '0 4 * * *'
-  SCHEDULE_DBSOLR_SYNC: '0 5 * * *'
+  SCHEDULE_SITEMAP: '0 2 * * *'
+  SCHEDULE_HARVESTING: '4/15 5-23 * * *'
+  SCHEDULE_STUCK_JOBS: '0 3 * * *'
+  SCHEDULE_DBSOLR_SYNC: '0 4 * * *'
 
 jobs:
   ckan-auto-command:

--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -5,7 +5,7 @@ on:   # yamllint disable-line rule:truthy
   schedule:
     - cron: '30 7 * * *'       # Tracking Update -- every day at 2:30am EST
     - cron: '0 2 * * *'        # S3 Sitemap Update -- every day at 7pm EST
-    - cron: '4/15 5-23 * * *'  # Harvester Check -- every 15 mins between 12am and 6pm EST
+    - cron: '4/15 5-23 * * *'  # Harvester Check -- every 15 mins between 12am and 6pm EST   # yamllint disable-line rule:line-length
     - cron: '0 3 * * *'        # DB-Solr-Sync -- every day at 10pm EST
     - cron: '0 4 * * *'        # Check Stuck Jobs -- every day at 11pm EST
 

--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -34,6 +34,9 @@ jobs:
           - app: catalog-admin
           # Default timeout for task to raise issue
           - error_seconds: 22000
+          # Create an Information Issue for jobs we want to inspect
+          - info_issue: false
+          - issue_template: .github/automated_ckan_error.md
           # Default monitor everything
           - monitor: true
           # Attach commands to schedule
@@ -47,21 +50,36 @@ jobs:
             command: "ckan geodatagov check-stuck-jobs"
           - schedule: $SCHEDULE_SITEMAP
             command: "ckan geodatagov sitemap-to-s3"
-          # Run sitemap-to-s3 on catalog-gather
+
+          # 'sitemap-to-s3' : Run on catalog-gather
           - schedule: $SCHEDULE_SITEMAP
             app: catalog-gather
-          # Don't monitor 'harvester run'
-          - schedule: $SCHEDULE_HARVESTING
-            monitor: false
-          # Don't monitor 'sitemap-to-s3'
+          # 'sitemap-to-s3': Don't monitor
           - schedule: $SCHEDULE_SITEMAP
             monitor: false
-          # If tracking update takes longer than 210 mins, make an issue
+
+          # 'harvester run': Don't monitor
+          - schedule: $SCHEDULE_HARVESTING
+            monitor: false
+
+          # 'tracking-update': make an issue if longer than 210 mins
           - schedule: $SCHEDULE_TRACKING
             error_seconds: 12600
-          # If db solr sync takes longer than 30 mins, make an issue
+          # 'tracking-update': Create informational issue
+          - schedule: $SCHEDULE_TRACKING
+            info_issue: true
+          - schedule: $SCHEDULE_TRACKING
+            issue_template: .github/tracking-update-info.md
+
+          # 'db-solr-sync': make an issue if longer than 30 mins
           - schedule: $SCHEDULE_DBSOLR_SYNC
             error_seconds: 1800
+          # 'db-solr-sync': Create informational issue
+          - schedule: $SCHEDULE_DBSOLR_SYNC
+            info_issue: true
+          - schedule: $SCHEDULE_DBSOLR_SYNC
+            issue_template: .github/db-solr-sync-info.md
+
           # Adjust RAM per space
           - environ: development
             ram: 1G
@@ -70,16 +88,18 @@ jobs:
           - environ: prod
             ram: 3G
         exclude:
-          # Don't run 'sitemap-to-s3' on development/staging
+          # 'sitemap-to-s3': Don't run on development/staging
           - schedule: $SCHEDULE_SITEMAP
             environ: development
           - schedule: $SCHEDULE_SITEMAP
             environ: staging
-          # Don't run 'db-solr-sync' + 'check-stuck-jobs' on development
+          # 'db-solr-sync': Don't run on development
           - schedule: $SCHEDULE_DBSOLR_SYNC
             environ: development
+          # 'check-stuck-jobs': Don't run on development
           - schedule: $SCHEDULE_STUCK_JOBS
             environ: development
+
     name: ${{ matrix.command }} - ${{matrix.environ}}
     runs-on: ubuntu-latest
     environment: ${{matrix.environ}}
@@ -91,7 +111,7 @@ jobs:
         run: |
           INSTANCE_NAME="$(echo ${{ matrix.command }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT} | tr -d ' ')"
           echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
-          START=$SECONDS | tee -a $GITHUB_ENV
+          START=`date +%s` | tee -a $GITHUB_ENV
           # yamllint enable rule:line-length
       - name: ${{ matrix.command }}
         if: ${{ github.event.schedule == matrix.schedule }}
@@ -118,9 +138,29 @@ jobs:
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
       - name: check runtime
         run: |
-          ELAPSED=$(( SECONDS - START))
-          echo "$START, $SECONDS, $ELAPSED"
-          if [[ $ELAPSED > ${{ matrix.error_seconds }} ]]; then ERROR=true | tee -a $GITHUB_ENV; fi;
+          END=`date +%s`
+          ELAPSED=$(( END - START))
+          echo "$START, $END, $ELAPSED"
+          if [[ $ELAPSED > ${{ matrix.error_seconds }} ]]; then echo ERROR=true | tee -a $GITHUB_ENV; fi;
+          if [[ $ELAPSED > ${{ matrix.error_seconds }} ]]; then echo "ELAPSED=${ELAPSED}" | tee -a $GITHUB_ENV; fi;
+      - name: Create Informational Issue for auditing 📑
+        if: ${{ matrix.info_issue }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GITHUB_JOB: ${{ toJson(github)['job'] }}
+          GITHUB_ATTEMPTS: ${{ github.run_attempt }}
+          LAST_COMMIT: ${{ github.sha }}
+          LAST_RUN_BY: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+          COMMAND: ${{ matrix.command }}
+          SCHEDULE: ${{ matrix.schedule }}
+          ENVIRONMENT: ${{ matrix.environ }}
+          EXEC_TIME: ${{ env.ELAPSED }}
+        with:
+          filename: ${{ matrix.issue_template }}
+          assignees: ${{ github.actor }}
+          update_existing: true
       - name: Create Issue if it fails 😢
         if: ${{ failure() || (env.ERROR == true) }}
         uses: JasonEtco/create-an-issue@v2

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -12,7 +12,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: Lint GitHub Actions
-        run: yamllint .github/workflows/
+        run: yamllint -d relaxed .github/workflows/
   test:
     name: Build and Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Related to
- #845 
- #822 

Changes:
- Add Harvesting 'Quiet Time'
- Simplify Schedule time management
- Disable `db-solr-sync` on development
- Disable `stuck-jobs` on development
- Disable hard-failure for yaml line too long

References:
- https://askubuntu.com/a/1158876
- https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration