### PR TITLE
Only update audit issue if on schedule

### DIFF
--- a/.github/db-solr-sync-info.md
+++ b/.github/db-solr-sync-info.md
@@ -1,10 +1,10 @@
 ---
 title: 📌 DB Solr Sync Auditing Log
-labels: bug
+labels: audit
 ---
 
 Workflow with Issue: {{ workflow }}
-Job Failed: {{ env.GITHUB_JOB }}
+Job being auditied: {{ env.GITHUB_JOB }}
 CKAN Command (in question): {{ env.COMMAND }}
 CKAN Command Schedule: {{ env.SCHEDULE }}
 Cloud.gov Environment: {{ env.ENVIRONMENT }}

--- a/.github/tracking-update-info.md
+++ b/.github/tracking-update-info.md
@@ -1,10 +1,10 @@
 ---
 title: 📌 Tracking Update Auditing Log
-labels: bug
+labels: audit
 ---
 
 Workflow with Issue: {{ workflow }}
-Job Failed: {{ env.GITHUB_JOB }}
+Job being audited: {{ env.GITHUB_JOB }}
 CKAN Command (in question): {{ env.COMMAND }}
 CKAN Command Schedule: {{ env.SCHEDULE }}
 Cloud.gov Environment: {{ env.ENVIRONMENT }}

--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -143,7 +143,7 @@ jobs:
           if [[ $ELAPSED > ${{ matrix.error_seconds }} ]]; then echo ERROR=true | tee -a $GITHUB_ENV; fi;
           if [[ $ELAPSED > ${{ matrix.error_seconds }} ]]; then echo "ELAPSED=${ELAPSED}" | tee -a $GITHUB_ENV; fi;
       - name: Create Informational Issue for auditing 📑
-        if: ${{ matrix.info_issue }}
+        if: ${{ matrix.info_issue && github.event.schedule == matrix.schedule }}
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4224
- #822 

Every run is 'updating' the audit issues with no meaningful information.  So make sure it only gets updated when it's scheduled to do some work.