### PR TITLE
new datajson version with the fix of missing field issue

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -11,7 +11,7 @@ git+https://github.com/keitaroinc/ckanext-saml2auth.git@main#egg=ckanext-saml2au
 
 ckanext-datagovcatalog>=0.0.3
 ckanext-datagovtheme>=0.1.22
-ckanext-datajson>=0.1.12
+ckanext-datajson>=0.1.13
 ckanext-envvars>=0.0.2
 ckanext-geodatagov>=0.1.27
 ckanext-googleanalyticsbasic

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -12,7 +12,7 @@ ckan==2.9.8
 -e git+https://github.com/ckan/ckanext-archiver.git@c96e3c81bfc430cdb0372f3307c7abd4109a80f1#egg=ckanext_archiver
 ckanext-datagovcatalog==0.0.5
 ckanext-datagovtheme==0.1.22
-ckanext-datajson==0.1.12
+ckanext-datajson==0.1.13
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@618928be5a211babafc45103a72b6aab4642e964
 ckanext-envvars==0.0.2
 ckanext-geodatagov==0.1.27


### PR DESCRIPTION
Related:
[Catalog harvest does not report error when data.json is invalid #3658](https://github.com/GSA/data.gov/issues/3658)
[gather fails on datajson record without an identifier#4080](https://github.com/GSA/data.gov/issues/4080)

Included checks for the dataset's `title` and `identifier `before referring to them. 
Code changes are here: https://github.com/GSA/ckanext-datajson/pull/137