### PR TITLE
GH Action - CKAN Command Manual Monitor Option

### DIFF
--- a/.github/workflows/ckan.yml
+++ b/.github/workflows/ckan.yml
@@ -35,16 +35,16 @@ on:   # yamllint disable-line rule:truthy
         required: true
         type: input
         default: '2G'
-      monitor:
-        description: 'Monitor log output?'
-        required: true
-        type: boolean
-        default: true
       disk:
         description: 'Disk space to allocate:'
         required: true
         type: input
         default: '1500M'
+      monitor:
+        description: 'Monitor log output?'
+        required: true
+        type: boolean
+        default: true
 
 
 jobs:

--- a/.github/workflows/ckan.yml
+++ b/.github/workflows/ckan.yml
@@ -35,6 +35,11 @@ on:   # yamllint disable-line rule:truthy
         required: true
         type: input
         default: '2G'
+      monitor:
+        description: 'Monitor log output?'
+        required: true
+        type: boolean
+        default: true
       disk:
         description: 'Disk space to allocate:'
         required: true
@@ -67,7 +72,7 @@ jobs:
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
       - name: monitor task output
-        if: ${{ inputs.command != 'ckan geodatagov sitemap-to-s3' }}
+        if: ${{ inputs.monitor }}
         uses: cloud-gov/cg-cli-tools@main
         with:
           command: >


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4238
- https://github.com/GSA/catalog.data.gov/issues/882

When running a manual task via github actions, it is best to specify whether you want to view log output in github action as an input option.