### PR TITLE
Add network-policies after deploy in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,7 +113,7 @@ jobs:
       - name: proxy to web
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: ${{ matrix. command }}
+          command: ${{ matrix.command }}
           cf_org: gsa-datagov
           cf_space: ${{ matrix.environ }}
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,3 +94,27 @@ jobs:
       app_names: "{\"include\":[{\"app\":\"catalog-web\",\"smoketest\":true},{\"app\":\"catalog-admin\"},{\"app\":\"catalog-fetch\"},{\"app\":\"catalog-gather\"},{\"app\":\"catalog-proxy\"}]}"
     secrets: inherit
     # yamllint enable rule:line-length
+
+  network-policies:
+    name: Add network-policies
+    needs:
+      - deploy-staging
+      - deploy-prod
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        command: [
+          "cf add-network-policy catalog-proxy catalog-web --protocol tcp --port 61443",
+          "cf add-network-policy catalog-proxy catalog-admin --protocol tcp --port 61443"
+        ]
+        environ: [ "staging", "prod" ]
+    steps:
+      - name: proxy to web
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: ${{ matrix. command }}
+          cf_org: gsa-datagov
+          cf_space: ${{ matrix.environ }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}


### PR DESCRIPTION
Related to
- https://github.com/GSA/catalog.data.gov/issues/892

Notes:
- This is not the most optimal deployment organization, but it is the most optimal deployment code definition.  
- Since we don't have true "smoke tests", it doesn't matter that the network-policies may or may not be configured directly after deployment.
- It is also assumed that the network policies already exist.  This is supposed to be just a backup if the policies don't exist.