### PR TITLE
input -> string

### DIFF
--- a/.github/workflows/ckan.yml
+++ b/.github/workflows/ckan.yml
@@ -15,7 +15,7 @@ on:   # yamllint disable-line rule:truthy
       app:
         description: 'App to run on:'
         required: true
-        type: input
+        type: string
         default: 'catalog-admin'
       command:
         description: 'Command to run:'
@@ -33,12 +33,12 @@ on:   # yamllint disable-line rule:truthy
       memory:
         description: 'RAM to allocate:'
         required: true
-        type: input
+        type: string
         default: '2G'
       disk:
         description: 'Disk space to allocate:'
         required: true
-        type: input
+        type: string
         default: '1500M'
       monitor:
         description: 'Monitor log output?'


### PR DESCRIPTION
When making the yamllint changes earlier, I noticed: 
![image](https://user-images.githubusercontent.com/91547795/228016586-e4493376-9d85-4740-b410-8ac828277943.png)

The [docs also seem to give the example](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatch) of `string` and not `input` for `type`s. I don't see this [action running regularly](https://github.com/GSA/catalog.data.gov/actions), so I might be misunderstanding the context of this.  