### PR TITLE
Revert "Temp Fix - CI cloudfoundry key"

### DIFF
--- a/.github/workflows/ckan.yml
+++ b/.github/workflows/ckan.yml
@@ -60,7 +60,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: run task
-        uses: gsa/cg-cli-tools@key-not-accessible
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: >
             cf run-task ${{ inputs.app }} --command "${{ inputs.command }}"
@@ -71,7 +71,7 @@ jobs:
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
       - name: monitor task output
         if: ${{ inputs.monitor }}
-        uses: gsa/cg-cli-tools@key-not-accessible
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: >
             tools/monitor_cf_logs.sh catalog-admin $INSTANCE_NAME

--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -109,7 +109,7 @@ jobs:
           echo "START=`date +%s`" | tee -a $GITHUB_ENV
       - name: ${{ matrix.command }}
         if: ${{ github.event.schedule == matrix.schedule }}
-        uses: gsa/cg-cli-tools@key-not-accessible
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: >
             cf run-task ${{ matrix.app }}
@@ -122,7 +122,7 @@ jobs:
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
       - name: monitor task output
         if: ${{ matrix.monitor && github.event.schedule == matrix.schedule }}
-        uses: gsa/cg-cli-tools@key-not-accessible
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: >
             tools/monitor_cf_logs.sh ${{ matrix.app }} $INSTANCE_NAME

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,7 +110,7 @@ jobs:
         environ: ["staging", "prod"]
     steps:
       - name: proxy to web
-        uses: gsa/cg-cli-tools@key-not-accessible
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: ${{ matrix.command }}
           cf_org: gsa-datagov


### PR DESCRIPTION
Related to
- GSA/catalog.data.gov#901
- https://github.com/GSA/data.gov/issues/4265

>[This issue](https://github.com/cloudfoundry/cli/issues/2390#issuecomment-1487670880) should be resolved by now. The primary reason is a new CDN security rule to fight bots. We will take additional steps to improve monitoring to respond faster to such incidents.

Hackers are only going to get worse and worse.