### PR TITLE
Owslib fixes

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -39,7 +39,7 @@ git+https://github.com/danizen/PyZ3950#egg=PyZ3950
 # ckanext-spatial
 argparse
 GeoAlchemy2==0.5.0
-OWSLib==0.18.0
+owslib>=0.28.1
 pyparsing>=2.1.10
 pyproj==2.6.1
 Shapely>=1.2.13

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -57,7 +57,7 @@ messytables==0.15.2
 newrelic==8.8.0
 nose==1.3.7
 numpy==1.24.2
-OWSLib==0.18.0
+owslib>=0.28.1
 packaging==23.0
 passlib==1.7.3
 PasteDeploy==2.0.1

--- a/e2e/cypress/integration/000_harvest.cy.js
+++ b/e2e/cypress/integration/000_harvest.cy.js
@@ -16,7 +16,7 @@ describe('Harvest', { testIsolation: false }, () => {
         // Create the organization
         cy.create_organization(harvestOrg, 'cypress harvest org description', false);
     });
-    
+
     after(() => {
         cy.logout();
         /**
@@ -114,36 +114,38 @@ describe('Harvest', { testIsolation: false }, () => {
         cy.check_dataset_harvested(5);
     });
 
-    it('Create CSW Harvest Source', () => {
-        /**
-         * Test creating a valid csw harvest source.
-         * Mocking a CSW harvest source is extremely complex,
-         * we took a shortcut and used a public endpoint.
-         * This test may fail in the future due to removal of
-         * the service not under our control, at that point we should
-         * remove the test or create a CSW service locally.
-         * Currently only 1 harvest endpoint is working for data.gov,
-         * so testing that use case seems appropriate. You can check
-         * how many harvest sources are created for CSW by going to
-         * https://catalog.data.gov/harvest?source_type=csw
-         */
+    // TODO: delete once we confirm dropping support for CSWs
+    // ####
+    // it('Create CSW Harvest Source', () => {
+    //     /**
+    //      * Test creating a valid csw harvest source.
+    //      * Mocking a CSW harvest source is extremely complex,
+    //      * we took a shortcut and used a public endpoint.
+    //      * This test may fail in the future due to removal of
+    //      * the service not under our control, at that point we should
+    //      * remove the test or create a CSW service locally.
+    //      * Currently only 1 harvest endpoint is working for data.gov,
+    //      * so testing that use case seems appropriate. You can check
+    //      * how many harvest sources are created for CSW by going to
+    //      * https://catalog.data.gov/harvest?source_type=csw
+    //      */
 
-        cy.create_harvest_source(
-            harvestOrg,
-            'https://geonode.state.gov/catalogue/csw',
-            cswHarvestSourceName,
-            'cypress test csw',
-            'csw',
-            'False',
-            false
-        );
+    //     cy.create_harvest_source(
+    //         harvestOrg,
+    //         'https://geonode.state.gov/catalogue/csw',
+    //         cswHarvestSourceName,
+    //         'cypress test csw',
+    //         'csw',
+    //         'False',
+    //         false
+    //     );
 
-        // harvestTitle must not contain spaces, otherwise the URL redirect will not confirm
-        cy.location('pathname').should('eq', '/harvest/' + cswHarvestSourceName);
-    });
+    //     // harvestTitle must not contain spaces, otherwise the URL redirect will not confirm
+    //     cy.location('pathname').should('eq', '/harvest/' + cswHarvestSourceName);
+    // });
 
-    it('Start CSW Harvest Job', () => {
-        cy.start_harvest_job(cswHarvestSourceName);
-        cy.check_dataset_harvested(5);
-    });
+    // it('Start CSW Harvest Job', () => {
+    //     cy.start_harvest_job(cswHarvestSourceName);
+    //     cy.check_dataset_harvested(5);
+    // });
 });

--- a/e2e/cypress/integration/zzz_cleanup.cy.js
+++ b/e2e/cypress/integration/zzz_cleanup.cy.js
@@ -3,7 +3,7 @@ describe('Cleanup site', () => {
     const dataJsonHarvestSoureName = 'test-harvest-datajson';
     const wafIsoHarvestSourceName = 'test-harvest-waf-iso';
     const wafFgdcHarvestSourceName = 'test-harvest-waf-fgdc';
-    const cswHarvestSourceName = 'test-harvest-csw';
+    // const cswHarvestSourceName = 'test-harvest-csw'; TODO: delete
 
     before(() => {
         cy.login();
@@ -12,7 +12,7 @@ describe('Cleanup site', () => {
         cy.delete_harvest_source(dataJsonHarvestSoureName);
         cy.delete_harvest_source(wafIsoHarvestSourceName);
         cy.delete_harvest_source(wafFgdcHarvestSourceName);
-        cy.delete_harvest_source(cswHarvestSourceName);
+        // cy.delete_harvest_source(cswHarvestSourceName); TODO: delete
 
         // Sometimes things are left in the DB locally, you can use this to delete 1-off datasets
         // cy.delete_dataset("invasive-plant-prioritization-for-inventory-and-early-detection-at-guadalupe-nipomo-dunes-");


### PR DESCRIPTION
Related to:
- https://github.com/GSA/data.gov/issues/4231

Background:
This patches the security exception flagged by Snyk, but also breaks ckanext-spatial's support for CSW sources. The intention is to eventually remove support for CSW's entirely, but until we confirm an upgrade path for our single CSW harvest source we will upgrade the lib and live with a broken CSW pipeline.