### PR TITLE
fix sitemap cron time

### DIFF
--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -4,7 +4,7 @@ name: 4 - Automated CKAN Jobs
 on:
   schedule:
     - cron: '30 7 * * *'       # Tracking Update -- every day at 2:30am EST
-    - cron: '0 0 * * *'        # S3 Sitemap Update -- every day at 7pm EST
+    - cron: '0 2 * * *'        # S3 Sitemap Update -- every day at 10pm EST
     - cron: '4/15 * * * *'     # Harvester Check -- every 15 mins
     - cron: '0 3 * * *'        # DB-Solr-Sync -- every day at 10pm EST
     - cron: '30 6 * * *'       # Check Stuck Jobs -- every day at 1:30am EST


### PR DESCRIPTION
The sitemap job cron times need to be matching to run. The current sitemap files haven't been updated since 2023-04-05. This PR changes the run time to 2am UTC (should be 10pm EST). 