### PR TITLE
bump cflinux to 3->4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudfoundry/cflinuxfs3
+FROM cloudfoundry/cflinuxfs4
 # Specify Python version
 ARG PY_VERSION=python3.8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN cd ~vcap/app
 RUN apt-get -y update
 RUN apt-get -y install software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get -y install swig build-essential libssl-dev python${PY_VERSION}-distutils
+RUN apt-get -y install swig build-essential python${PY_VERSION}-dev libssl-dev python${PY_VERSION}-distutils
 RUN apt-get -y install python${PY_VERSION}
 
 # Install PIP

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get -y install python${PY_VERSION}
 
 # Install PIP
 RUN curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
-RUN ${PY_VERSION} /tmp/get-pip.py
+RUN python${PY_VERSION} /tmp/get-pip.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN cd ~vcap/app
 RUN apt-get -y update
 RUN apt-get -y install software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get -y install swig build-essential python-dev libssl-dev ${PY_VERSION}-distutils
+RUN apt-get -y install swig build-essential python-dev${PY_VERSION} libssl-dev ${PY_VERSION}-distutils
 RUN apt-get -y install ${PY_VERSION}
 
 # Install PIP

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM cloudfoundry/cflinuxfs4
 # Specify Python version
-ARG PY_VERSION=python3.8
+ARG PY_VERSION=3.8
 
 # Go where the app files are
 RUN cd ~vcap/app
@@ -9,8 +9,8 @@ RUN cd ~vcap/app
 RUN apt-get -y update
 RUN apt-get -y install software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get -y install swig build-essential python-dev${PY_VERSION} libssl-dev ${PY_VERSION}-distutils
-RUN apt-get -y install ${PY_VERSION}
+RUN apt-get -y install swig build-essential python-dev${PY_VERSION} libssl-dev python${PY_VERSION}-distutils
+RUN apt-get -y install python${PY_VERSION}
 
 # Install PIP
 RUN curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN cd ~vcap/app
 RUN apt-get -y update
 RUN apt-get -y install software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get -y install swig build-essential python-dev${PY_VERSION} libssl-dev python${PY_VERSION}-distutils
+RUN apt-get -y install swig build-essential libssl-dev python${PY_VERSION}-distutils
 RUN apt-get -y install python${PY_VERSION}
 
 # Install PIP


### PR DESCRIPTION
@FuhuXia , I'm seeing 
<img width="900" alt="image" src="https://user-images.githubusercontent.com/91547795/234972886-3bf8698b-0500-41cf-87dd-e7022b1eaf2b.png">
in the catalog staging logs. Do you think this is the problem?

It looks like [`cflinuxfs3` has been deprecated](https://blogs.sap.com/2023/02/16/deprecation-of-cloud-foundry-stack-cflinuxfs3-and-migration-to-cflinuxfs4/) in favor of `4`. 