### PR TITLE
pinned to newer buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ applications:
   - name: ((app_name))-web
     buildpacks:
       - https://github.com/cloudfoundry/apt-buildpack
-      - https://github.com/cloudfoundry/python-buildpack.git#v1.7.58 #to fix transitive dep issue: https://github.com/cloudfoundry/python-buildpack/issues/574
+      - https://github.com/cloudfoundry/python-buildpack.git#v1.8.4 # pinned for this https://github.com/GSA/data.gov/issues/4259
     services:
       - ((app_name))-db
       - ((app_name))-redis
@@ -33,7 +33,7 @@ applications:
   - name: ((app_name))-admin
     buildpacks:
       - https://github.com/cloudfoundry/apt-buildpack
-      - https://github.com/cloudfoundry/python-buildpack.git#v1.7.58  #to fix transitive dep issue: https://github.com/cloudfoundry/python-buildpack/issues/574
+      - https://github.com/cloudfoundry/python-buildpack.git#v1.8.4 # pinned for this https://github.com/GSA/data.gov/issues/4259
     services:
       - ((app_name))-db
       - ((app_name))-redis
@@ -82,7 +82,7 @@ applications:
   - name: ((app_name))-gather
     buildpacks:
       - https://github.com/cloudfoundry/apt-buildpack
-      - https://github.com/cloudfoundry/python-buildpack.git#v1.7.58  #to fix transitive dep issue: https://github.com/cloudfoundry/python-buildpack/issues/574
+      - https://github.com/cloudfoundry/python-buildpack.git#v1.8.4 # pinned for this https://github.com/GSA/data.gov/issues/4259
     services:
       - ((app_name))-db
       - ((app_name))-redis
@@ -109,7 +109,7 @@ applications:
   - name: ((app_name))-fetch
     buildpacks:
       - https://github.com/cloudfoundry/apt-buildpack
-      - https://github.com/cloudfoundry/python-buildpack.git#v1.7.58  #to fix transitive dep issue: https://github.com/cloudfoundry/python-buildpack/issues/574
+      - https://github.com/cloudfoundry/python-buildpack.git#v1.8.4 # pinned for this https://github.com/GSA/data.gov/issues/4259
     services:
       - ((app_name))-db
       - ((app_name))-redis


### PR DESCRIPTION
cant use 1.7.58 any more. use 1.8.4, same as inventory.
eventually we need to get [this](https://github.com/GSA/data.gov/issues/4259) fixed and use latest python buildpack.