### PR TITLE
add http_proxy

### DIFF
--- a/.profile
+++ b/.profile
@@ -13,6 +13,7 @@ echo "Setting up egress proxy.."
 if [ -z ${proxy_url+x} ]; then
   echo "Egress proxy is not connected."
 else
+  export http_proxy=$proxy_url
   export https_proxy=$proxy_url
 fi
 


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/4112

add `http_proxy`, along side with `https_proxy`, so that HTTP traffic can be regulated as well.

After egress-proxy [PR](https://github.com/GSA-TTS/cg-egress-proxy/pull/32) merged, port 80 traffic will be blocked.