### PR TITLE
create our own auth_tkt cookie

### DIFF
--- a/proxy/nginx-authy.conf
+++ b/proxy/nginx-authy.conf
@@ -1,7 +1,41 @@
+##################################
+# CKAN used to add an auth_tkt cookie for logged-in user
+# It is gone after 2.10. Let us generate our own auth_tkt here.
+# If the request comes from login.gov and goes to /user/me,
+# we know the user is logged in.
+set $check "";
+set $cookiecontent "";
+set $goodauth "auth_tkt=1; PATH=/";
+set $badauth "auth_tkt=0; PATH=/";
+
+if ($uri = "/user/me") {
+  set $check "endpointcheck";
+}
+if ($http_referer ~* \.(login|identitysandbox).gov/$ ) {
+  set $check "${check}+referercheck";
+}
+if ($check = "endpointcheck+referercheck") {
+  set $cookiecontent $goodauth;
+}
+if ($uri = "/user/logged_out_redirect") {
+  set $cookiecontent $badauth;
+}
+
+add_header Set-Cookie $cookiecontent;
+
+if ($uri = "/user/logged_out_redirect") {
+  return 302 https://{{env "PUBLIC_ROUTE"}}$uri;
+}
+
+##########################################
+# If cookie auth_tkt does not have a good value,
+# we dont serve the request on the admin site.
+# We 302 redirect it to the public site,
+# except some special uri listed below:
 set $authy "";
 
-# Determine if auth cookie is set
-if ($cookie_auth_tkt) {
+# Determine if auth cookie is set with good value
+if ($cookie_auth_tkt = 1) {
   set $authy C;
 }
 if ($uri = "/user/saml2login") {
@@ -9,6 +43,9 @@ if ($uri = "/user/saml2login") {
 }
 if ($uri = "/acs") {
   set $authy "${authy}S";
+}
+if ($uri = "/user/me") {
+  set $authy "${authy}M";
 }
 if ($uri = "/api/action/status_show") {
   set $authy "${authy}H";

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -47,7 +47,7 @@ http {
     # catalog-admin
     server_name {{env "EXTERNAL_ROUTE_ADMIN"}};
 
-    # include nginx-authy.conf;
+    include nginx-authy.conf;
     include nginx-common.conf;
   }
 }


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/4371

If a request comes from `login.gov` and goes to uri `/user/me`, we assume it means a successful authentication, therefore we add the session cookie `auth_tkt` and give it a good value. The purpose of this cookie is to stop anonymous requests from accessing the admin site.