### PR TITLE
catalog dev and stage url

### DIFF
--- a/vars.development.yml
+++ b/vars.development.yml
@@ -15,7 +15,7 @@ gather_memory_quota: 1G
 new_relic_monitor_mode: false
 
 # use CDN domain for route-public if available, otherwise use route-external 
-route-public: d2jqk88ququ1n9.cloudfront.net
+route-public: catalog-dev.data.gov
 route-external: catalog-dev-datagov.app.cloud.gov
 route-internal: catalog-dev-datagov.apps.internal
 route-external-admin: catalog-dev-admin-datagov.app.cloud.gov

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -15,7 +15,7 @@ gather_memory_quota: 3G
 new_relic_monitor_mode: true
 
 # use CDN domain for route-public if available, otherwise use route-external 
-route-public: d1u59lafwydg4a.cloudfront.net
+route-public: catalog-stage.data.gov
 route-external: catalog-stage-datagov.app.cloud.gov
 route-internal: catalog-stage-datagov.apps.internal
 route-external-admin: catalog-stage-admin-datagov.app.cloud.gov


### PR DESCRIPTION
we can use the friendly urls now after the 18F DNS latest change.