### PR TITLE
stop backend jobs on prod to lock DB, preparing ckan210 release

### DIFF
--- a/.github/workflows/ckan.yml
+++ b/.github/workflows/ckan.yml
@@ -10,7 +10,6 @@ on:
         type: choice
         options:
           - development
-          - prod
       app:
         description: 'App to run on:'
         required: true

--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -58,7 +58,7 @@ jobs:
             "schedule": ["${{env.SCHEDULE_TRACKING}}", "${{env.SCHEDULE_SITEMAP}}",
                          "${{env.SCHEDULE_HARVESTING}}", "${{env.SCHEDULE_STUCK_JOBS}}",
                          "${{env.SCHEDULE_DBSOLR_SYNC}}", "${{ env.SCHEDULE_GEN_REPORT}}"],
-            "environ": ["development", "prod"],
+            "environ": ["development"],
             "include": [ {"app": "catalog-admin"},
                          {"error_seconds": 22000},
                          {"info_issue": false},
@@ -78,8 +78,7 @@ jobs:
                          {"schedule": "${{env.SCHEDULE_STUCK_JOBS}}", "command": "ckan geodatagov check-stuck-jobs"},
                          {"schedule": "${{env.SCHEDULE_GEN_REPORT}}", "command": "ckan report generate"},
                          {"schedule": "${{env.SCHEDULE_GEN_REPORT}}", "issue_template": ".github/report-generation-failure.md"},
-                         {"environ": "development", "ram": "1G"},
-                         {"environ": "prod", "ram": "2500M"}
+                         {"environ": "development", "ram": "1G"}
                        ],
             "exclude": [ {"schedule": "${{env.SCHEDULE_SITEMAP}}", "environ": "development"},
                          {"schedule": "${{env.SCHEDULE_DBSOLR_SYNC}}", "environ": "development"},

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,13 +40,6 @@ jobs:
           push: true
           tags: ${{ matrix.tag }}
 
-  create-cloudgov-services-staging:
-    name: create services (staging)
-    uses: gsa/data.gov/.github/workflows/create-services-template.yml@main
-    with:
-      environ: staging
-    secrets: inherit
-
   create-cloudgov-services-prod:
     name: create services (prod)
     uses: gsa/data.gov/.github/workflows/create-services-template.yml@main
@@ -54,22 +47,10 @@ jobs:
       environ: prod
     secrets: inherit
 
-  deploy-staging:
-    name: deploy (staging)
-    needs:
-      - create-cloudgov-services-staging
-    uses: gsa/data.gov/.github/workflows/deploy-template.yml@main
-    with:
-      environ: staging
-      app_url: https://catalog-stage-datagov.app.cloud.gov
-      app_names: "{\"include\":[{\"app\":\"catalog-web\",\"smoketest\":true},{\"app\":\"catalog-admin\"},{\"app\":\"catalog-fetch\"},{\"app\":\"catalog-gather\"},{\"app\":\"catalog-proxy\"}]}"
-    secrets: inherit
-
   deploy-prod:
     name: deploy (prod)
     needs:
       - create-cloudgov-services-prod
-      - deploy-staging
     uses: gsa/data.gov/.github/workflows/deploy-template.yml@main
     with:
       environ: prod
@@ -80,7 +61,6 @@ jobs:
   network-policies:
     name: Add network-policies
     needs:
-      - deploy-staging
       - deploy-prod
     runs-on: ubuntu-latest
     environment: ${{ matrix.environ }}
@@ -91,7 +71,7 @@ jobs:
           "cf add-network-policy catalog-proxy catalog-web --protocol tcp --port 61443",
           "cf add-network-policy catalog-proxy catalog-admin --protocol tcp --port 61443"
         ]
-        environ: ["staging", "prod"]
+        environ: ["prod"]
     steps:
       - name: proxy to web
         uses: cloud-gov/cg-cli-tools@main

--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -15,10 +15,10 @@ jobs:
   #     app_names: "{\"include\":[{\"app\":\"catalog-proxy\"},{\"app\":\"catalog-gather\"},{\"app\":\"catalog-fetch\"},{\"app\":\"catalog-web\"},{\"app\":\"catalog-admin\"},]}"
   #   secrets: inherit
 
-  restart-prod:
-    name: restart (prod)
+  restart-development:
+    name: restart (development)
     uses: gsa/data.gov/.github/workflows/app-restart-template.yml@main
     with:
-      environ: prod
+      environ: development
       app_names: "{\"include\":[{\"app\":\"catalog-proxy\"},{\"app\":\"catalog-gather\"},{\"app\":\"catalog-fetch\"},{\"app\":\"catalog-web\"},{\"app\":\"catalog-admin\"},]}"
     secrets: inherit

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -7,8 +7,8 @@ ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.production.idp.xm
 
 web-instances: 5
 admin-instances: 1
-gather-instances: 1
-fetch-instances: 4
+gather-instances: 0
+fetch-instances: 0
 memory_quota: 850M
 gather_memory_quota: 3G
 


### PR DESCRIPTION
stop backend jobs on prod to lock DB, preparing ckan210 release
staging has been upgrade during dryrun, so no staging deployment.

This and [previous stop-staging PR](https://github.com/GSA/catalog.data.gov/pull/982) will get reverted once ckan-210 upgrade completes. 