### PR TITLE
Get Snyk Scan to run again

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -4,7 +4,7 @@ git+https://github.com/ckan/ckanext-dcat@master#egg=ckanext-dcat
 -e git+https://github.com/ckan/ckanext-harvest.git@master#egg=ckanext-harvest
 -e git+https://github.com/GSA/ckanext-spatial.git@v2-0-0-gsa#egg=ckanext-spatial
 git+https://github.com/GSA/ckanext-saml2auth.git@create_user_via_saml#egg=ckanext-saml2auth
--e git+https://github.com/ckan/ckanext-qa.git@master#egg=ckanext-qa
+# -e git+https://github.com/ckan/ckanext-qa.git@master#egg=ckanext-qa
 -e git+https://github.com/ckan/ckanext-archiver.git@master#egg=ckanext-archiver
 -e git+https://github.com/ckan/ckanext-report.git@master#egg=ckanext-report
 

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -22,7 +22,7 @@ ckanext-geodatagov==0.2.1
 ckanext-googleanalyticsbasic==0.2.1
 -e git+https://github.com/ckan/ckanext-harvest.git@9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4#egg=ckanext_harvest
 ckanext-metrics-dashboard==0.1.6
--e git+https://github.com/ckan/ckanext-qa.git@1731b59d2bf82b06f7866c204b26eb7c6c9ea1f9#egg=ckanext_qa
+# -e git+https://github.com/ckan/ckanext-qa.git@1731b59d2bf82b06f7866c204b26eb7c6c9ea1f9#egg=ckanext_qa
 -e git+https://github.com/ckan/ckanext-report.git@3588577f46d17e5f6ef163bb984d0e7016daef71#egg=ckanext_report
 ckanext-saml2auth @ git+https://github.com/GSA/ckanext-saml2auth.git@c2b12a94430034c522b25d282323a064e2d6a03a
 -e git+https://github.com/GSA/ckanext-spatial.git@f8e0ad7af15425e8df3f650a602f85f1e77526ff#egg=ckanext_spatial

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -98,7 +98,7 @@ requests==2.31.0
 rfc3987==1.3.8
 rq==1.11.0
 s3transfer==0.6.1
-setuptools==67.1.0
+setuptools==67.6.0
 shapely==2.0.1
 simplejson==3.18.0
 six==1.16.0


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4409

Changes:
- `ckanext-qa` has issues to install
- `setuptools` has a bug in an earlier version.