### PR TITLE
Add workflow to check egress status

### DIFF
--- a/.github/egress_check_error.md
+++ b/.github/egress_check_error.md
@@ -1,0 +1,15 @@
+---
+title: Egress Check Failed
+labels: bug o&m egress
+---
+
+Workflow with Issue: {{ workflow }}
+Job Failed: {{ env.GITHUB_JOB }}
+Type of Failure: {{ env.COMMAND }}
+Location of Failure: {{ env.APP_NAME }}
+Cloud.gov Environment: {{ env.ENVIRONMENT }}
+
+Last Commit: {{ env.LAST_COMMIT }}
+Number of times run: {{ env.GITHUB_ATTEMPTS }}
+Last run by: {{ env.LAST_RUN_BY }}
+Github Action Run: https://github.com/GSA/catalog.data.gov/actions/runs/{{ env.RUN_ID }}

--- a/.github/workflows/ckan.yml
+++ b/.github/workflows/ckan.yml
@@ -75,7 +75,7 @@ jobs:
         uses: cloud-gov/cg-cli-tools@main
         with:
           command: >
-            tools/monitor_cf_logs.sh catalog-admin $INSTANCE_NAME
+            tools/monitor_cf_logs.sh ${{ inputs.app }} $INSTANCE_NAME
           cf_org: gsa-datagov
           cf_space: ${{ inputs.environ }}
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/egress_check.yml
+++ b/.github/workflows/egress_check.yml
@@ -2,6 +2,8 @@
 name: 6 - Check Egress Operation
 
 on:
+  schedule:
+    - cron: '*/5 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/egress_check.yml
+++ b/.github/workflows/egress_check.yml
@@ -22,7 +22,6 @@ jobs:
         environ: ['development', 'staging', 'prod']
         app:
           - 'catalog-admin'
-          - 'catalog-proxy'
           - 'catalog-web'
           - 'catalog-fetch'
           - 'catalog-gather'

--- a/.github/workflows/egress_check.yml
+++ b/.github/workflows/egress_check.yml
@@ -1,0 +1,68 @@
+---
+name: 6 - Check Egress Operation
+
+on:
+  workflow_dispatch:
+
+jobs:
+  egress-check:
+    name: ${{ matrix.app - matrix-environ - matrix.command }}
+    runs-on: ubuntu-latest
+    environment: ${{ matrix.environ }}
+    strategy:
+      fail-fast: false
+      matrix:
+        command:
+          - 'G; curl -I -Ls --http1.1 https://gsa.gov | grep -q "HTTP/1.1 200 OK"'
+          - 'B; curl -I -Ls --http1.1 https://yahoo.com | grep -q "HTTP/1.1 403 Forbidden"'
+        environ: ['development', 'staging', 'prod']
+        app:
+          - 'catalog-admin'
+          - 'catalog-proxy'
+          - 'catalog-web'
+          - 'catalog-fetch'
+          - 'catalog-gather'
+
+    steps:
+      - name: Store Instance Name
+        run: |
+          INSTANCE_NAME="$(echo egress-check-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT})"
+          echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: run task
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            cf run-task ${{ matrix.app }} --command "${{ matrix.command }}"
+            --name $INSTANCE_NAME -k 1500M -m 150M
+          cf_org: gsa-datagov
+          cf_space: ${{ matrix.environ }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: monitor task output
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            tools/monitor_cf_logs.sh ${{ matrix.app }} $INSTANCE_NAME
+          cf_org: gsa-datagov
+          cf_space: ${{ matrix.environ }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: Create Issue for failure 😢
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GITHUB_JOB: ${{ toJson(github)['job'] }}
+          GITHUB_ATTEMPTS: ${{ github.run_attempt }}
+          LAST_COMMIT: ${{ github.sha }}
+          LAST_RUN_BY: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+          COMMAND: ${{ matrix.command }}
+          APP_NAME: ${{ matrix.app }}
+          ENVIRONMENT: ${{ matrix.environ }}
+        with:
+          filename: .github/egress_check_error.md
+          assignees: ${{ github.actor }}
+          update_existing: true

--- a/.github/workflows/egress_check.yml
+++ b/.github/workflows/egress_check.yml
@@ -15,8 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         command:
-          - 'G; curl -I -Ls --http1.1 https://gsa.gov | grep -q "HTTP/1.1 200 OK"'
-          - 'B; curl -I -Ls --http1.1 https://yahoo.com | grep -q "HTTP/1.1 403 Forbidden"'
+          - '#GoodDomainTest;
+             curl -I -Ls --http1.1 https://gsa.gov | grep -q "HTTP/1.1 200 OK"'
+          - '#BadDomainTest;
+             curl -I -Ls --http1.1 https://yahoo.com | grep -q "HTTP/1.1 403 Forbidden"'
         environ: ['development', 'staging', 'prod']
         app:
           - 'catalog-admin'


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4407

Notes:
- New issue template if check fails
- Run on all catalog apps
- Minimum memory (tested) was 100M, 150M given for buffer
- Run every 5 minutes to gauge current status (will decrease in the future).
- '#GoodDomainTest' prefix is for the title to know it's a good domain test (i.e. Allowed to go out)
- '#BadDomainTest' prefix is for the title to know it's a bad domain test (i.e. Not allowed to go out)
- Fix the `ckan.yml` workflow dispatch to monitor the correct app (instead of always `catalog-admin`)