### PR TITLE
Fix monitor logs script

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+##############################################################################
+# NOTE: When adding commands to this file, be mindful of sensitive output.
+# Since these logs are publicly available in github actions, we don't want
+# to leak anything.
+##############################################################################
+
 set -o errexit
 set -o pipefail
 
@@ -146,7 +152,7 @@ echo "$SAML2_CERTIFICATE" > $CKANEXT__SAML2AUTH__CERT_FILE_PATH
 
 # Setting up PostGIS
 echo Setting up PostGIS
-DATABASE_URL=$CKAN_SQLALCHEMY_URL python3 configure-postgis.py
+DATABASE_URL=$CKAN_SQLALCHEMY_URL python3 configure-postgis.py >/dev/null 2>&1
 
 # Edit the config file to use our values
 export CKAN_INI="${HOME}/ckan/setup/ckan.ini"

--- a/tools/monitor_cf_logs.sh
+++ b/tools/monitor_cf_logs.sh
@@ -8,7 +8,7 @@ app_to_monitor=$1
 task_to_monitor=$2
 
 while read -r line ; do
-  echo "$line" | grep --line-buffered " DEBUG \| INFO \| WARNING \| ERROR "
+  echo "$line"
   if echo "$line" | grep "OUT Exit status 0"; then
     exit 0
   elif echo "$line" | grep "OUT Exit status"; then


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4417

Notes:
- Since we monitor non-ckan logs now too, the old solution didn't work.
- Instead, let's just silence things that have senstive information, so that we can see more relevant log output 🧷 