### PR TITLE
Add PUBLIC_ROUTE into nginx server_name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,15 @@ test: build
 	# docker build -t ghcr.io/gsa/catalog.data.gov:latest ckan/
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit test
 
+# everytime you added some new variables, you need to swap it with some test values
+# and swap it back after the test. This is because "nginx -t" test cannot read env variables.
 validate-proxy:
 	sed -i 's/{{nameservers}}/127.0.0.1/g' proxy/nginx.conf
 	sed -i 's/{{env "EXTERNAL_ROUTE"}}/127.0.0.2/g' proxy/nginx.conf proxy/nginx-cloudfront.conf
 	sed -i 's/{{env "INTERNAL_ROUTE"}}/127.0.0.3/g' proxy/nginx.conf
 	sed -i 's/{{env "EXTERNAL_ROUTE_ADMIN"}}/127.0.0.4/g' proxy/nginx.conf
 	sed -i 's/{{env "INTERNAL_ROUTE_ADMIN"}}/127.0.0.5/g' proxy/nginx.conf
+	sed -i 's/{{env "PUBLIC_ROUTE"}}/127.0.0.6/g' proxy/nginx.conf proxy/nginx-cloudfront.conf
 	sed -i 's/{{port}}/1111/g' proxy/nginx.conf proxy/nginx-common.conf
 	sed -i 's/{{env "PUBLIC_ROUTE"}}/test.com/g' proxy/nginx-cloudfront.conf proxy/nginx-authy.conf
 	sed -i 's#{{env "S3_URL"}}#http://test.com#g' proxy/nginx-common.conf
@@ -62,6 +65,7 @@ validate-proxy:
 	sed -i 's/127.0.0.3/{{env "INTERNAL_ROUTE"}}/g' proxy/nginx.conf
 	sed -i 's/127.0.0.4/{{env "EXTERNAL_ROUTE_ADMIN"}}/g' proxy/nginx.conf
 	sed -i 's/127.0.0.5/{{env "INTERNAL_ROUTE_ADMIN"}}/g' proxy/nginx.conf
+	sed -i 's/127.0.0.6/{{env "PUBLIC_ROUTE"}}/g' proxy/nginx.conf proxy/nginx-cloudfront.conf
 	sed -i 's/1111/{{port}}/g' proxy/nginx.conf proxy/nginx-common.conf
 	sed -i 's/test.com/{{env "PUBLIC_ROUTE"}}/g' proxy/nginx-cloudfront.conf
 	sed -i 's#http://test.com#{{env "S3_URL"}}#g' proxy/nginx-common.conf

--- a/proxy/nginx-cloudfront.conf
+++ b/proxy/nginx-cloudfront.conf
@@ -9,11 +9,13 @@ if ($uri = "/api/action/status_show") {
   set $onlyCF "${onlyCF}letMeIn,";
 }
 
+# we use EXTERNAL_ROUTE != PUBLIC_ROUTE to determine if we are behind a CDN
 if ($somevariable != {{env "PUBLIC_ROUTE"}}) {
   set $onlyCF "${onlyCF}onCDN,";
 }
 
-if ($http_user_agent != "Amazon CloudFront") {
+# If host in request head is not public_route, then it is not from CloudFront
+if ($http_host != {{env "PUBLIC_ROUTE"}}) {
   set $onlyCF "${onlyCF}notFromCF";
 }
 

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -21,6 +21,7 @@ http {
 
   # talk to the right internal app
   map $server_name $internal_url {
+    {{env "PUBLIC_ROUTE"}} {{env "INTERNAL_ROUTE"}};
     {{env "EXTERNAL_ROUTE"}} {{env "INTERNAL_ROUTE"}};
     {{env "EXTERNAL_ROUTE_ADMIN"}} {{env "INTERNAL_ROUTE_ADMIN"}};
   }
@@ -34,7 +35,7 @@ http {
   ## Gunicorn specs
   server {
     # catalog-web
-    server_name {{env "EXTERNAL_ROUTE"}};
+    server_name {{env "EXTERNAL_ROUTE"}} {{env "PUBLIC_ROUTE"}};
 
     auth_basic           auth_configured; # this is a placeholder value replaced by .profile. we should only add basic auth to staging.
     auth_basic_user_file /home/vcap/app/etc/nginx/.htpasswd;

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -40,7 +40,7 @@ http {
     auth_basic           auth_configured; # this is a placeholder value replaced by .profile. we should only add basic auth to staging.
     auth_basic_user_file /home/vcap/app/etc/nginx/.htpasswd;
 
-    include nginx-cloudfront.conf;
+    # include nginx-cloudfront.conf;
     include nginx-common.conf;
   }
 


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/4413

On CloudFront we will add `HOST` and `USER-AGENT` into the header.  We need to change nginx conf accordingly. This is the 3-step deployment.
1. Add PUBLIC_ROUTE as new host, but disable `nginx-cloudfront` check
2. TODO: apply new CloudFront settings
3. TODO: re-enable `nginx-cloudfront` check.