### PR TITLE
step 3 of nginx deployment

### DIFF
--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -37,10 +37,10 @@ http {
     # catalog-web
     server_name {{env "EXTERNAL_ROUTE"}} {{env "PUBLIC_ROUTE"}};
 
-    auth_basic           auth_configured; # this is a placeholder value replaced by .profile. we should only add basic auth to staging.
-    auth_basic_user_file /home/vcap/app/etc/nginx/.htpasswd;
+    # auth_basic           auth_configured; # this is a placeholder value replaced by .profile. we should only add basic auth to staging.
+    # auth_basic_user_file /home/vcap/app/etc/nginx/.htpasswd;
 
-    # include nginx-cloudfront.conf;
+    include nginx-cloudfront.conf;
     include nginx-common.conf;
   }
 


### PR DESCRIPTION
redo step 3 of https://github.com/GSA/catalog.data.gov/pull/1046

- renabling nginx-cloudfront
- disable basic auth on staging for now. we will keep staging down until we find a good way to add basic auth back to staging.