### PR TITLE
Remove basic auth

### DIFF
--- a/docs/CloudFront/README.md
+++ b/docs/CloudFront/README.md
@@ -1,0 +1,5 @@
+The data.gov team has deployed its own CloudFront service on the SSB AWS account, instead of using the CloudFront that comes with cloud.gov. This gives us finer control over the CloudFront configurations and allows us to use the latest CloudFront features.
+
+The CloudFront for catalog.data.gov is hosted on the ssb-production AWS account. The CloudFront for catalog-stage.data.gov and catalog-dev.data.gov are hosted on the ssb-development AWS account.
+
+This document contains the CloudFront configurations for all three apps.

--- a/proxy/.profile
+++ b/proxy/.profile
@@ -15,23 +15,8 @@ APP_NAME=$(echo "$VCAP_APPLICATION" | jq -r '.application_name')
 export APP_NAME
 SPACE_NAME=$(echo "$VCAP_APPLICATION" | jq -r '.space_name')
 export SPACE_NAME
-PROXY_AUTH_USERNAME=$(vcap_get_service secrets .credentials.PROXY_AUTH.USERNAME)
-export PROXY_AUTH_USERNAME
-PROXY_AUTH_PASSWORD=$(vcap_get_service secrets .credentials.PROXY_AUTH.PASSWORD)
-export PROXY_AUTH_PASSWORD
 
 echo "Setting up proxy in $APP_NAME on $SPACE_NAME"
-
-if [[ "$PROXY_AUTH_USERNAME" = null ]] && [[ "$PROXY_AUTH_PASSWORD" = null ]]
-then
-    echo "Proxy auth and username absent, not setting proxy basic auth..."
-    export BASIC_AUTH_ENABLED=off ;
-else
-    echo "Proxy auth and username are present, setting proxy basic auth..."
-    echo "$PROXY_AUTH_USERNAME:$PROXY_AUTH_PASSWORD" > "${HOME}"/etc/nginx/.htpasswd
-    export BASIC_AUTH_ENABLED='"Catalog-Web restricted"' ;
-fi
-sed -i "s/auth_configured/${BASIC_AUTH_ENABLED}/" ./nginx.conf
 
 # sitemap config
 # url constructed in nginx conf

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -37,9 +37,6 @@ http {
     # catalog-web
     server_name {{env "EXTERNAL_ROUTE"}} {{env "PUBLIC_ROUTE"}};
 
-    # auth_basic           auth_configured; # this is a placeholder value replaced by .profile. we should only add basic auth to staging.
-    # auth_basic_user_file /home/vcap/app/etc/nginx/.htpasswd;
-
     include nginx-cloudfront.conf;
     include nginx-common.conf;
   }


### PR DESCRIPTION
We deployed basic auth on the CloudFront. We can remove the basic auth configuration in the nginx.  