### PR TITLE
Disable new dataset creation

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.2.0
 ckan==2.10.1
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.0
-ckanext-datagovtheme==0.2.3
+ckanext-datagovtheme==0.2.4
 ckanext-datajson==0.1.21
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@008a3e2f22a352d7ded9dd988dc69e654f58cd87
 ckanext-envvars==0.0.3

--- a/proxy/nginx-common.conf
+++ b/proxy/nginx-common.conf
@@ -80,3 +80,8 @@ error_page 500 502 503 504 /500.html;
 location = /500.html {
   root ./public;
 }
+
+# prevent users from accessing '/dataset/new' route
+location = /dataset/new {
+    deny all;
+}


### PR DESCRIPTION
• blocks `/dataset/new` route in nginx