### PR TITLE
exclude bots from tracking

### DIFF
--- a/proxy/nginx-botbegone.conf
+++ b/proxy/nginx-botbegone.conf
@@ -1,0 +1,21 @@
+# prevent top 6 bots from entering data into /_tracking
+## Googlebot/
+## Y!J
+## Yeti
+## Bytespider
+## Applebot
+## HeadlessChrome
+
+set $botstracking 0;
+
+if ($uri = "/_tracking") {
+  set $botstracking 1;
+}
+
+if ($http_user_agent ~ 'Googlebot/|Y!J|Yeti|Bytespider|Applebot|HeadlessChrome') {
+  set $botstracking "${botstracking}1";
+}
+
+if ($botstracking = 11) {
+  return 200;
+}

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -38,6 +38,7 @@ http {
     server_name {{env "EXTERNAL_ROUTE"}} {{env "PUBLIC_ROUTE"}};
 
     include nginx-cloudfront.conf;
+    include nginx-botbegone.conf;
     include nginx-common.conf;
   }
 


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/4452

Stop top bots from entering data into _tracking, responding with an emtpy page.