### PR TITLE
reduce max-parallel for Egress check from 4 to 2

### DIFF
--- a/.github/workflows/egress_check.yml
+++ b/.github/workflows/egress_check.yml
@@ -13,7 +13,7 @@ jobs:
     environment: ${{ matrix.environ }}
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 2
       matrix:
         command:
           - 'GoodDomainTest || curl -I -L --http1.1 https://gsa.gov | grep \"HTTP/1.1 200 OK\"'


### PR DESCRIPTION
When check-egress jobs failed due to `memory_in_mb exceeds organization memory quota`, it tends to fail on the 5th or 6th job. Probably it has something to do with our `max-parallel: 4` setting. Let us see if making it 2 will alleviate the problem. 