### PR TITLE
update ckanext-googleanalytics

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -18,7 +18,7 @@ ckanext-datajson==0.1.21
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@33498dfb13ef87facc549184e5a355e06a2a5457
 ckanext-envvars==0.0.3
 ckanext-geodatagov==0.2.7
--e git+https://github.com/ckan/ckanext-googleanalytics.git@3402d747e726fb8eb1d793da703b5a3249432c0a#egg=ckanext_googleanalytics
+-e git+https://github.com/ckan/ckanext-googleanalytics.git@24d9a7ff62235bc2d543e6594f7362763411b0f9#egg=ckanext_googleanalytics
 -e git+https://github.com/ckan/ckanext-harvest.git@9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4#egg=ckanext_harvest
 ckanext-metrics-dashboard==0.1.6
 -e git+https://github.com/ckan/ckanext-report.git@3588577f46d17e5f6ef163bb984d0e7016daef71#egg=ckanext_report


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/4508

Bringing [changes from upstream](https://github.com/ckan/ckanext-googleanalytics/pull/72) to use HTTPS for `www.google-analytics.com`.