### PR TITLE
use python 3.9 for snyk

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,7 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
       - name: Install Dependencies
         run: |
           npm install snyk -g


### PR DESCRIPTION
related 
- https://github.com/GSA/data.gov/issues/4481

3.10 has problem during setup, so we use version 3.9 to match CKAN docker.