### PR TITLE
have to pin to python 3.9 to avoid problem

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -50,7 +50,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.9'
           architecture: x64
       - name: test_importer
         run: make test-import-tool


### PR DESCRIPTION
similar to https://github.com/GSA/catalog.data.gov/pull/1116

without this, it loads the latest `3.12.0`. Too far advanced. Our catalog is on `3.9`.