### PR TITLE
added new werkzeug exception 6035177

### DIFF
--- a/ckan/.snyk
+++ b/ckan/.snyk
@@ -15,7 +15,7 @@ ignore:
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4217
         expires: 2023-12-31T16:20:58.017Z
-        created: 2023-02-15T16:20:58.023Z
+        created: 2023-10-30T16:50:58.023Z
   SNYK-PYTHON-WERKZEUG-3319936:
     - '*':
         reason: >-

--- a/ckan/.snyk
+++ b/ckan/.snyk
@@ -9,25 +9,32 @@ ignore:
           not accessible to any other client
         expires: 2023-12-31T16:20:58.017Z
         created: 2022-12-08T16:20:58.023Z
+  SNYK-PYTHON-WERKZEUG-6035177:
+    - '*':
+        reason: >-
+          Upgrade path is complex, Issue tracked in github:
+          https://github.com/GSA/data.gov/issues/4217
+        expires: 2023-12-31T16:20:58.017Z
+        created: 2023-02-15T16:20:58.023Z
   SNYK-PYTHON-WERKZEUG-3319936:
     - '*':
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4217
-        expires: 2023-10-31T16:20:58.017Z
+        expires: 2023-12-31T16:20:58.017Z
         created: 2023-02-15T16:20:58.023Z
   SNYK-PYTHON-WERKZEUG-3319935:
     - '*':
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4217
-        expires: 2023-10-31T16:20:58.017Z
+        expires: 2023-12-31T16:20:58.017Z
         created: 2023-02-15T16:20:58.023Z
   SNYK-PYTHON-FLASK-5490129:
     - '*':
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4303
-        expires: 2023-10-31T16:20:58.017Z
+        expires: 2023-12-31T16:20:58.017Z
         created: 2023-05-08T16:20:58.023Z
 patch: {}


### PR DESCRIPTION
added new werkzeug exception to ignore known vulnerabilities
extended the expired date for others.

related  https://github.com/GSA/data.gov/issues/4217