### PR TITLE
load map tiles with trial account

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -23,7 +23,7 @@ ckanext-geodatagov==0.2.7
 ckanext-metrics-dashboard==0.1.6
 -e git+https://github.com/ckan/ckanext-report.git@3588577f46d17e5f6ef163bb984d0e7016daef71#egg=ckanext_report
 ckanext-saml2auth @ git+https://github.com/GSA/ckanext-saml2auth.git@4d59366423ed965ba86a7b85547a6bd9f4351869
--e git+https://github.com/GSA/ckanext-spatial.git@6c92b9b5aedf19dc6a4737222372898ecae77e7f#egg=ckanext_spatial
+-e git+https://github.com/GSA/ckanext-spatial.git@60ce4135d780b2ae917a308fc72d97fbd7feddd3#egg=ckanext_spatial
 ckantoolkit==0.0.7
 click==8.1.3
 cryptography==41.0.5


### PR DESCRIPTION
This loads changes from https://github.com/GSA/ckanext-spatial/commit/60ce4135d780b2ae917a308fc72d97fbd7feddd3

For https://github.com/GSA/data.gov/issues/4493.

We set up a trial account, got a API, to load the map tiles from the new location, just to see how much traffic we are expecting.

Due to https://github.com/GSA/data.gov/issues/4518, we have to hard code the new url and API key, not in the ckan.ini

The API key is ok to be open and visible.