### PR TITLE
update spatial to remove API key

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -23,7 +23,7 @@ ckanext-geodatagov==0.2.7
 ckanext-metrics-dashboard==0.1.6
 -e git+https://github.com/ckan/ckanext-report.git@3588577f46d17e5f6ef163bb984d0e7016daef71#egg=ckanext_report
 ckanext-saml2auth @ git+https://github.com/GSA/ckanext-saml2auth.git@4d59366423ed965ba86a7b85547a6bd9f4351869
--e git+https://github.com/GSA/ckanext-spatial.git@60ce4135d780b2ae917a308fc72d97fbd7feddd3#egg=ckanext_spatial
+-e git+https://github.com/GSA/ckanext-spatial.git@4d1612f47eee3f2de162e932711ce3cfbaa60d96#egg=ckanext_spatial
 ckantoolkit==0.0.7
 click==8.1.3
 cryptography==41.0.5


### PR DESCRIPTION
This remove the use of the API key of the trial account. Instead, we use domain authorization on the Stadia trial account. 