### PR TITLE
Map tiles

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,19 @@ CKANEXT__GEODATAGOV__BUREAU_CSV__URL_DEFAULT=https://resources.data.gov/schemas/
 
 CKAN__SPATIAL__SRID=4326
 CKAN__SPATIAL__VALIDATOR__PROFILES=iso19139ngdc
+
 CKANEXT__SPATIAL__SEARCH_BACKEND=solr-bbox
+# Customize map widget
+CKANEXT__SPATIAL__COMMON_MAP__TYPE=custom
+
+# CKANEXT__SPATIAL__COMMON_MAP__CUSTOM_URL=https://tile.openstreetmap.org/{z}/{x}/{y}.png
+# CKANEXT__SPATIAL__COMMON_MAP__ATTRIBUTION=<a href=https://openstreetmap.org/>OpenStreetMap</a> contributors
+
+# CKANEXT__SPATIAL__COMMON_MAP__CUSTOM_URL=https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}
+# CKANEXT__SPATIAL__COMMON_MAP__ATTRIBUTION=Tiles courtesy of the <a href="https://usgs.gov/">U.S. Geological Survey</a>
+
+CKANEXT__SPATIAL__COMMON_MAP__CUSTOM_URL=https://tiles.stadiamaps.com/tiles/stamen_terrain/{z}/{x}/{y}{r}.png
+CKANEXT__SPATIAL__COMMON_MAP__ATTRIBUTION=<a href=https://stadiamaps.com/>Stadia Maps</a>. <a href=https://openstreetmap.org/>OpenStreetMap</a> contributors
 
 CKAN___GOOGLEANALYTICS__ID=UA-00000000-0
 CKAN__TRACKING_ENABLED=true

--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -3,7 +3,7 @@ ckan==2.10.1
 git+https://github.com/ckan/ckanext-dcat@master#egg=ckanext-dcat
 -e git+https://github.com/ckan/ckanext-harvest.git@master#egg=ckanext-harvest
 -e git+https://github.com/ckan/ckanext-googleanalytics.git@master#egg=ckanext-googleanalytics
--e git+https://github.com/GSA/ckanext-spatial.git@v2-0-0-gsa#egg=ckanext-spatial
+-e git+https://github.com/ckan/ckanext-spatial.git@v2.1.0#egg=ckanext-spatial
 git+https://github.com/GSA/ckanext-saml2auth.git@create_user_via_saml.log_210#egg=ckanext-saml2auth
 # -e git+https://github.com/ckan/ckanext-qa.git@master#egg=ckanext-qa
 -e git+https://github.com/ckan/ckanext-archiver.git@master#egg=ckanext-archiver

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.3.1
 ckan==2.10.1
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.0
-ckanext-datagovtheme==0.2.4
+ckanext-datagovtheme==0.2.5
 ckanext-datajson==0.1.21
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@33498dfb13ef87facc549184e5a355e06a2a5457
 ckanext-envvars==0.0.3
@@ -23,7 +23,7 @@ ckanext-geodatagov==0.2.7
 ckanext-metrics-dashboard==0.1.6
 -e git+https://github.com/ckan/ckanext-report.git@3588577f46d17e5f6ef163bb984d0e7016daef71#egg=ckanext_report
 ckanext-saml2auth @ git+https://github.com/GSA/ckanext-saml2auth.git@4d59366423ed965ba86a7b85547a6bd9f4351869
--e git+https://github.com/GSA/ckanext-spatial.git@4d1612f47eee3f2de162e932711ce3cfbaa60d96#egg=ckanext_spatial
+-e git+https://github.com/ckan/ckanext-spatial.git@9c866b106313a90f327c11bbfab1d6a76eb45f77#egg=ckanext_spatial
 ckantoolkit==0.0.7
 click==8.1.3
 cryptography==41.0.5

--- a/ckan/setup/ckan.ini
+++ b/ckan/setup/ckan.ini
@@ -229,6 +229,17 @@ ckan.tracking_enabled = True
 
 ## Spatial settings
 ckanext.spatial.search_backend = solr-bbox
+# Customize map widget
+ckanext.spatial.common_map.type = custom
+
+# ckanext.spatial.common_map.custom_url = /maptiles/{z}/{x}/{y}.png
+# ckanext.spatial.common_map.attribution = <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors
+
+# ckanext.spatial.common_map.custom_url = https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}
+# ckanext.spatial.common_map.attribution = Tiles courtesy of the <a href="https://usgs.gov/">U.S. Geological Survey</a>
+
+ckanext.spatial.common_map.custom_url = https://tiles.stadiamaps.com/tiles/stamen_terrain/{z}/{x}/{y}{r}.png
+ckanext.spatial.common_map.attribution = <a href=https://stadiamaps.com/>Stadia Maps</a>. <a href=https://openstreetmap.org/>OpenStreetMap</a> contributors
 
 ## Harvest settings
 # ckanext-harvest will use ckan.redis.url if redis configuration

--- a/proxy/nginx-common.conf
+++ b/proxy/nginx-common.conf
@@ -85,3 +85,17 @@ location = /500.html {
 location ~ ^/(dataset\/new|api\/action\/package_create|api\/action\/resource_create)/?$ {
   deny all;
 }
+
+# use local path for map tiles so that they
+# can be cached by the CDN
+location /maptiles {
+  # only allow requests generated from data.gov
+  valid_referers server_names  *.data.gov;
+  if ($invalid_referer) {
+    return   403;
+  }
+  
+  rewrite ^/maptiles/(.*)/(.*)/(.*).png$ /$1/$2/$3.png break;
+  proxy_redirect off;
+  proxy_pass https://tile.openstreetmap.org/;
+}


### PR DESCRIPTION
This PR makes it ready for us to pick and choose the map tile servers

- Add custom map widget to ckan.ini, three choices
- add /maptiles in nginx so that map tiles can be cached in the CDN
- update dependencies for datagovtheme and upstream spatial