### PR TITLE
switch map tile server to openstreetmap.org

### DIFF
--- a/ckan/setup/ckan.ini
+++ b/ckan/setup/ckan.ini
@@ -232,14 +232,14 @@ ckanext.spatial.search_backend = solr-bbox
 # Customize map widget
 ckanext.spatial.common_map.type = custom
 
-# ckanext.spatial.common_map.custom_url = /maptiles/{z}/{x}/{y}.png
-# ckanext.spatial.common_map.attribution = <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors
+ckanext.spatial.common_map.custom_url = /maptiles/{z}/{x}/{y}.png
+ckanext.spatial.common_map.attribution = <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors
 
 # ckanext.spatial.common_map.custom_url = https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}
 # ckanext.spatial.common_map.attribution = Tiles courtesy of the <a href="https://usgs.gov/">U.S. Geological Survey</a>
 
-ckanext.spatial.common_map.custom_url = https://tiles.stadiamaps.com/tiles/stamen_terrain/{z}/{x}/{y}{r}.png
-ckanext.spatial.common_map.attribution = <a href=https://stadiamaps.com/>Stadia Maps</a>. <a href=https://openstreetmap.org/>OpenStreetMap</a> contributors
+# ckanext.spatial.common_map.custom_url = https://tiles.stadiamaps.com/tiles/stamen_terrain/{z}/{x}/{y}{r}.png
+# ckanext.spatial.common_map.attribution = <a href=https://stadiamaps.com/>Stadia Maps</a>. <a href=https://openstreetmap.org/>OpenStreetMap</a> contributors
 
 ## Harvest settings
 # ckanext-harvest will use ckan.redis.url if redis configuration

--- a/proxy/nginx-common.conf
+++ b/proxy/nginx-common.conf
@@ -89,8 +89,8 @@ location ~ ^/(dataset\/new|api\/action\/package_create|api\/action\/resource_cre
 # use local path for map tiles so that they
 # can be cached by the CDN
 location /maptiles {
-  # only allow requests generated from data.gov
-  valid_referers server_names  *.data.gov;
+  # only allow requests generated from our apps
+  valid_referers server_names *.data.gov *admin-datagov.app.cloud.gov;
   if ($invalid_referer) {
     return   403;
   }

--- a/proxy/nginx-common.conf
+++ b/proxy/nginx-common.conf
@@ -90,7 +90,7 @@ location ~ ^/(dataset\/new|api\/action\/package_create|api\/action\/resource_cre
 # can be cached by the CDN
 location /maptiles {
   # only allow requests generated from our apps
-  valid_referers server_names *.data.gov *admin-datagov.app.cloud.gov;
+  valid_referers server_names *.data.gov *.app.cloud.gov;
   if ($invalid_referer) {
     return   403;
   }


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/4493
- changed to openstreetmap cached map tiles
- make sure requests to from referer *.data.gov *admin-datagov.app.cloud.gov