### PR TITLE
better grep

### DIFF
--- a/tools/monitor_cf_logs.sh
+++ b/tools/monitor_cf_logs.sh
@@ -7,6 +7,9 @@
 app_to_monitor=$1
 task_to_monitor=$2
 
+# install a better version of grep which supports --line-buffered
+apk add grep 
+
 while read -r line ; do
   echo "$line"
   if echo "$line" | grep "OUT Exit status 0"; then


### PR DESCRIPTION
Started to see this error in the **monitor task output** step,as in https://github.com/GSA/catalog.data.gov/actions/runs/6901149024/job/18775455943
```
Running command: tools/monitor_cf_logs.sh catalog-admin $INSTANCE_NAME
grep: unrecognized option: line-buffered
BusyBox v1.36.1 (2023-11-06 11:32:24 UTC) multi-call binary.
```

It means something in the `cloud-gov/cg-cli-tools` has been changed recently that the built-in `grep` does not support `line-buffered` any more. So we install a new grep.