### PR TITLE
pin harvest to latest release, not commit number

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -1,7 +1,7 @@
 # CKAN requirements and extensions
 ckan==2.10.1
 git+https://github.com/ckan/ckanext-dcat@master#egg=ckanext-dcat
--e git+https://github.com/ckan/ckanext-harvest.git@9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4#egg=ckanext-harvest
+-e git+https://github.com/ckan/ckanext-harvest.git@v1.5.6#egg=ckanext-harvest
 -e git+https://github.com/ckan/ckanext-googleanalytics.git@master#egg=ckanext-googleanalytics
 -e git+https://github.com/ckan/ckanext-spatial.git@v2.1.1#egg=ckanext-spatial
 git+https://github.com/GSA/ckanext-saml2auth.git@create_user_via_saml.log_210#egg=ckanext-saml2auth

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -4,9 +4,9 @@ Babel==2.10.3
 Beaker==1.11.0
 bleach==3.3.0
 blinker==1.5
-boto3==1.29.2
-botocore==1.32.2
-certifi==2023.7.22
+boto3==1.29.7
+botocore==1.32.7
+certifi==2023.11.17
 cffi==1.16.0
 chardet==5.2.0
 charset-normalizer==3.3.2
@@ -47,7 +47,7 @@ greenlet==3.0.1
 gunicorn==21.2.0
 html5lib==1.1
 httplib2==0.22.0
-idna==3.4
+idna==3.6
 importlib-metadata==6.8.0
 importlib-resources==5.13.0
 isodate==0.6.1
@@ -61,7 +61,7 @@ Mako==1.3.0
 Markdown==3.4.1
 MarkupSafe==2.1.3
 messytables==0.15.2
-mypy==1.7.0
+mypy==1.7.1
 mypy-extensions==1.0.0
 newrelic==9.2.0
 nose==1.3.7
@@ -79,7 +79,7 @@ polib==1.1.1
 progressbar==2.5
 progressbar2==3.53.3
 psycopg2==2.9.3
-pyasn1==0.5.0
+pyasn1==0.5.1
 pyasn1-modules==0.3.0
 pycparser==2.21
 PyJWT==2.4.0
@@ -102,7 +102,7 @@ requests==2.31.0
 rfc3987==1.3.8
 rq==1.11.0
 rsa==4.9
-s3transfer==0.7.0
+s3transfer==0.8.0
 sansjson==0.3.0
 setuptools==67.1.0
 shapely==2.0.1
@@ -120,7 +120,7 @@ urllib3==1.26.18
 webassets==2.0
 webencodings==0.5.1
 Werkzeug==2.0.0
-wheel==0.41.2
+wheel==0.41.3
 WTForms==3.1.1
 xlrd==2.0.1
 xmlschema==2.5.0


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/4529

stay with latest harvester stable release, not chasing master.