### PR TITLE
do egress check twice a day, not every hour

### DIFF
--- a/.github/workflows/egress_check.yml
+++ b/.github/workflows/egress_check.yml
@@ -3,7 +3,7 @@ name: 6 - Check Egress Operation
 
 on:
   schedule:
-    - cron: '40 * * * *'
+    - cron: '40 02,14 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
our gather/fetch restart script to checking log timestamp and restart them only if the log is stale for 40 minutes. Checking egress every hour keeps the logs fresh and gives restart script little chance to be executed. 

egress check twice a day is sufficient. 