### PR TITLE
Maintenance page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ validate-proxy:
 	sed -i 's#{{env "S3_URL"}}#http://test.com#g' proxy/nginx-common.conf
 	sed -i 's#{{env "S3_BUCKET"}}#somebucket#g' proxy/nginx-common.conf
 	sed -i 's#{{env "DENY_PACKAGE_CREATE"}}#truetodeny#g' proxy/nginx-common.conf
+	sed -i 's#{{env "CATALOG_WEB_MODE"}}#maintenancemaybe#g' proxy/nginx.conf
+	sed -i 's#{{env "CATALOG_ADMIN_MODE"}}#maintenancemaybe#g' proxy/nginx.conf
 	docker run --rm -e nameservers=127.0.0.1 -v $(shell pwd)/proxy:/proxy nginx nginx -t -c /proxy/nginx.conf
 	sed -i 's/127.0.0.1/{{nameservers}}/g' proxy/nginx.conf
 	sed -i 's/127.0.0.2/{{env "EXTERNAL_ROUTE"}}/g' proxy/nginx.conf proxy/nginx-cloudfront.conf
@@ -72,6 +74,8 @@ validate-proxy:
 	sed -i 's#http://test.com#{{env "S3_URL"}}#g' proxy/nginx-common.conf
 	sed -i 's#somebucket#{{env "S3_BUCKET"}}#g' proxy/nginx-common.conf
 	sed -i 's/truetodeny/{{env "DENY_PACKAGE_CREATE"}}/g' proxy/nginx-common.conf
+	sed -i 's/maintenancemaybe/{{env "CATALOG_WEB_MODE"}}/g' proxy/nginx.conf
+	sed -i 's/maintenancemaybe/{{env "CATALOG_ADMIN_MODE"}}/g' proxy/nginx.conf
 
 quick-bat-test:
 	# if local environment is already build and running

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ validate-proxy:
 	sed -i 's#{{env "S3_URL"}}#http://test.com#g' proxy/nginx-common.conf
 	sed -i 's#{{env "S3_BUCKET"}}#somebucket#g' proxy/nginx-common.conf
 	sed -i 's#{{env "DENY_PACKAGE_CREATE"}}#truetodeny#g' proxy/nginx-common.conf
-	sed -i 's#{{env "CATALOG_WEB_MODE"}}#maintenancemaybe#g' proxy/nginx.conf
-	sed -i 's#{{env "CATALOG_ADMIN_MODE"}}#maintenancemaybe#g' proxy/nginx.conf
+	sed -i 's#{{env "CATALOG_WEB_MODE"}}#webmaintenance#g' proxy/nginx.conf
+	sed -i 's#{{env "CATALOG_ADMIN_MODE"}}#adminmaintenance#g' proxy/nginx.conf
 	docker run --rm -e nameservers=127.0.0.1 -v $(shell pwd)/proxy:/proxy nginx nginx -t -c /proxy/nginx.conf
 	sed -i 's/127.0.0.1/{{nameservers}}/g' proxy/nginx.conf
 	sed -i 's/127.0.0.2/{{env "EXTERNAL_ROUTE"}}/g' proxy/nginx.conf proxy/nginx-cloudfront.conf
@@ -74,8 +74,8 @@ validate-proxy:
 	sed -i 's#http://test.com#{{env "S3_URL"}}#g' proxy/nginx-common.conf
 	sed -i 's#somebucket#{{env "S3_BUCKET"}}#g' proxy/nginx-common.conf
 	sed -i 's/truetodeny/{{env "DENY_PACKAGE_CREATE"}}/g' proxy/nginx-common.conf
-	sed -i 's/maintenancemaybe/{{env "CATALOG_WEB_MODE"}}/g' proxy/nginx.conf
-	sed -i 's/maintenancemaybe/{{env "CATALOG_ADMIN_MODE"}}/g' proxy/nginx.conf
+	sed -i 's/webmaintenance/{{env "CATALOG_WEB_MODE"}}/g' proxy/nginx.conf
+	sed -i 's/adminmaintenance/{{env "CATALOG_ADMIN_MODE"}}/g' proxy/nginx.conf
 
 quick-bat-test:
 	# if local environment is already build and running

--- a/README.md
+++ b/README.md
@@ -241,3 +241,8 @@ You can log into your instance with you login.gov user.
 Continuous Integration via [GitHub Actions](https://github.com/GSA/catalog.data.gov/actions/workflows/commit.yml).
 
 Continuous Deployment via [GitHub Actions](https://github.com/GSA/catalog.data.gov/actions/workflows/publish.yml).
+
+
+## Put site into maintenance mode
+
+To block access to the catalog apps (`catalog-web`, `catalog-admin`), set the environment variables (`CATALOG_WEB_MODE`, `CATALOG_ADMIN_MODE`) in the `catalog-proxy` app. Use 'MAINTENANCE' for scheduled downtime, 'DOWN' for unscheduled downtime. Any other value will resume normal operation.

--- a/proxy/nginx-common.conf
+++ b/proxy/nginx-common.conf
@@ -76,10 +76,13 @@ location /sitemap {
   proxy_pass https://${s3_url}/${s3_bucket}$request_uri;
 }
 
-error_page 500 502 503 504 /500.html;
+proxy_intercept_errors on;
+error_page 500 502 504 /500.html;
 location = /500.html {
   root ./public;
 }
+# NGINX searches for a URI that starts with /static-assets/ in the ./public/static-assets/ directory
+location /static-assets/ {}
 
 # prevent users from accessing: '/dataset/new' route, 'package_create' and 'resource_create' API routes
 location ~ ^/(dataset\/new|api\/action\/package_create|api\/action\/resource_create)/?$ {
@@ -103,3 +106,4 @@ location /maptiles {
   proxy_redirect off;
   proxy_pass https://tile.openstreetmap.org/;
 }
+

--- a/proxy/nginx-maintenance.conf
+++ b/proxy/nginx-maintenance.conf
@@ -1,0 +1,42 @@
+## This will put the site into maintenance mode depending on the environment variable.
+
+# $operation_mode is set from {{env "CATALOG_WEB_MODE"}} or {{env "CATALOG_ADMIN_MODE"}}
+# from previous nginx configuration
+# it is '' if the environment variable is not set
+set $takedown "0";
+if ($operation_mode = 'MAINTENANCE') {
+  set $takedown "1";
+}
+if ($operation_mode = 'DOWN') {
+  set $takedown "2";
+}
+# Allow access to the following paths
+if ($uri = "/api/action/status_show") {
+  set $takedown "0";
+}
+if ($uri = "/user/saml2login") {
+  set $takedown "0";
+}
+if ($uri ~* "/static-assets/") {
+  set $takedown "0";
+}
+
+if ($takedown != "0") {
+  return 503;
+}
+error_page 503 @maintenance;
+location @maintenance {
+  if ($takedown = "1") {
+    rewrite ^(.*)$ /maintenance.html break;
+  }
+  if ($takedown = "2") {
+    rewrite ^(.*)$ /sitedown.html break;
+  }
+  rewrite ^(.*)$ /500.html break;
+}
+location = /maintenance.html {
+  root ./public;
+}
+location = /sitedown.html {
+  root ./public;
+}

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -41,6 +41,8 @@ http {
     include nginx-badbot403.conf;
     include nginx-goodbot200.conf;
     include nginx-common.conf;
+    set $operation_mode '{{env "CATALOG_WEB_MODE"}}';
+    include nginx-maintenance.conf;
   }
 
   server {
@@ -49,6 +51,8 @@ http {
 
     include nginx-authy.conf;
     include nginx-common.conf;
+    set $operation_mode '{{env "CATALOG_ADMIN_MODE"}}';
+    include nginx-maintenance.conf;
   }
 }
 

--- a/proxy/public/maintenance.html
+++ b/proxy/public/maintenance.html
@@ -1,0 +1,402 @@
+
+<!DOCTYPE html>
+<!--[if IE 9]> <html lang="en" class="ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en"  > <!--<![endif]-->
+  <head>
+      <meta name="generator" content="ckan 2.10.1" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>503 Site under maintenance</title>
+
+    
+    
+    <link rel="shortcut icon" href="/static-assets/images/favicon.ico" />
+    
+      
+      <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+    
+
+    
+    <link href="/static-assets/css/93c09e07_main.css" rel="stylesheet"/>
+<link href="/static-assets/css/datagovtheme.css" rel="stylesheet"/>
+    
+  </head>
+
+  
+  <body data-site-root="https://catalog.data.gov/" data-locale-root="https://catalog.data.gov/" >
+
+    
+    
+        
+    
+
+    
+    <div class="visually-hidden-focusable"><a href="#content">Skip to main content</a></div>
+  
+
+  
+    
+<section class="usa-banner" aria-label="Official government website">
+    <div class="usa-accordion">
+        <header class="usa-banner__header">
+            <div class="usa-banner__inner">
+                <div class="grid-col-auto">
+                    <img class="usa-banner__header-flag" src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/us_flag_small.png" alt="U.S. flag" />
+                </div>
+                <div class="grid-col-fill tablet:grid-col-auto">
+                    <p class="usa-banner__header-text">
+                        An official website of the United States government
+                    </p>
+                    <p class="usa-banner__header-action" aria-hidden="true">
+                        Here's how you know
+                    </p>
+                </div>
+                <button type="button" class="usa-accordion__button usa-banner__button" aria-expanded="false"
+                    aria-controls="gov-banner-default-default">
+                    <span class="usa-banner__button-text">Here's how you know</span>
+                </button>
+            </div>
+        </header>
+        <div class="usa-banner__content usa-accordion__content" id="gov-banner-default-default">
+            <script>document.getElementById('gov-banner-default-default').setAttribute('hidden', '');</script>
+            <div class="grid-row grid-gap-lg">
+                <div class="usa-banner__guidance tablet:grid-col-6">
+                    <img class="usa-banner__icon usa-media-block__img" src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/icon-dot-gov.svg" role="img"
+                        alt="" aria-hidden="true" />
+                    <div class="usa-media-block__body">
+                        <p>
+                            <strong>Official websites use .gov</strong><br />A
+                            <strong>.gov</strong> website belongs to an official government
+                            organization in the United States.
+                        </p>
+                    </div>
+                </div>
+                <div class="usa-banner__guidance tablet:grid-col-6">
+                    <img class="usa-banner__icon usa-media-block__img" src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/icon-https.svg" role="img"
+                        alt="" aria-hidden="true" />
+                    <div class="usa-media-block__body">
+                        <p>
+                            <strong>Secure .gov websites use HTTPS</strong><br />A
+                            <strong>lock</strong> (
+                            <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64"
+                                    viewBox="0 0 52 64" class="usa-banner__lock-image" role="img"
+                                    aria-labelledby="banner-lock-title-default banner-lock-description-default"
+                                    focusable="false">
+                                    <title id="banner-lock-title-default">Lock</title>
+                                    <desc id="banner-lock-description-default">A locked padlock</desc>
+                                    <path fill="#000000" fill-rule="evenodd"
+                                        d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z" />
+                                </svg> </span>) or <strong>https://</strong> means you’ve safely connected to
+                            the .gov website. Share sensitive information only on official,
+                            secure websites.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<a href="#content" class="hide">Skip to content</a>
+<section class="usa-header usa-header--extended" role="banner">
+    <div class="grid-container">
+        <div class="grid-row">
+            <div class="grid-col-fill desktop:grid-col-auto">
+                <div class="usa-navbar">
+                    <div class="usa-logo" id="extended-logo">
+                        <em class="usa-logo__text"><a href="https://data.gov" title="Home" aria-label="Home"></a></em>
+                    </div>
+
+                    <button class="usa-menu-btn">Menu</button>
+                </div>
+            </div>
+            <div class="grid-col-auto desktop:grid-col-fill">
+                <nav id="menu-navigation" aria-label="Menu navigation" role="navigation" class="usa-nav">
+                    <div class="usa-nav__inner">
+                        <button class="usa-nav__close">
+                            <img src="/static-assets/images/close.svg" alt="Close" />
+                        </button>
+                        
+                            
+                            
+                        
+                        <ul class="usa-nav__primary usa-accordion">
+                            <li class="usa-nav__primary-item">
+                                <a class="usa-nav__link usa-current" href="/"><span class="text-uppercase">Data</span></a>
+                            </li>
+                            <li class="usa-nav__primary-item">
+                                <a class="usa-nav__link " href="/report"><span class="text-uppercase">Reports</span></a>
+                            </li>
+                            <li class="usa-nav__primary-item">
+                                <a class="usa-nav__link" href="https://data.gov/open-gov/"><span class="text-uppercase">Open Government</span></a>
+                            </li>
+                            <li class="usa-nav__primary-item">
+                                <a class="usa-nav__link" href="https://data.gov/contact/"><span class="text-uppercase">Contact</span></a>
+                            </li>
+                            <li class="usa-nav__primary-item desktop-hide">
+                                <a class="usa-nav__link" href="https://data.gov/user-guide/"><span class="text-uppercase">User Guide</span></a>
+                            </li>
+                        </ul>
+                        <div class="usa-nav__secondary">
+                            <ul class="usa-nav__secondary-links">
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
+            </div>
+            <div class="grid-col-auto user-guide__col desktop-show text-center">
+                <a href="https://data.gov/user-guide/">
+                    <img src="/static-assets/images/user-guide.svg" alt="User Guide" />
+                    <div class="user-guide__text">User Guide</div>
+                </a>
+            </div>
+        </div>
+        <hgroup class="top">
+            
+            <div class="account-wrapper">
+                
+            </div>
+            
+        </hgroup>
+    </div>
+</section>
+
+
+
+<header class="navbar navbar-static-top masthead">
+    
+    <div class="header_new banner_new page-heading_new">
+        <div class="container">
+            <div class="page-header_new">
+                <div class="main-heading">
+                    <h1>
+                        Data Catalog
+                    </h1>
+                </div>
+
+                <div class="toolbar">
+                        
+                        <ol class="breadcrumb">
+                            <li class="home"><a href="/dataset/"><i class="fa fa-home"></i><span> Home</span></a></li>
+                            <li><a href="/dataset/">Datasets</a></li>
+                        </ol>
+                        
+                    <div class="add_action">
+                        <a href="/organization/" class="btn btn_new">Organizations</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>
+
+  
+    
+<div role="main" class="controller- action-">
+    
+      <div id="content" class="container">
+        
+          
+  
+  
+
+
+          
+            <div class="toolbar" role="navigation" aria-label="Breadcrumb">
+              
+
+            </div>
+          
+
+          <div class="row wrapper no-nav">
+            
+            
+            
+
+            
+
+            
+  <article class="module">
+    <div class="module-content">
+      
+      <h1>Site Under Maintenance</h1>
+      
+      We are currently performing scheduled maintenance on our website.
+      <br><br>
+      We anticipate the maintenance to take approximately <b>15 minutes</b>. Please try again later.
+    </div>
+    
+    
+  
+  </article>
+
+          </div>
+        
+      </div>
+    </div>
+   <footer class="usa-footer site-footer" role="contentinfo">
+    <div class="footer-section-bottom bg-base-lighter">
+        <div class="grid-container">
+            <div class="grid-row padding-y-3">
+                <div class="tablet:grid-col-auto">
+                    <div class="logo-links">
+                        <a class="footer-logo media_link" href="https://data.gov">
+                            <img
+                                class="width-30 height-auto"
+                                src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/logo.png"
+                                alt="Data.gov logo"
+                            />
+                        </a>
+                    </div>
+                    <ul class="grid-row grid-gap" id="menu-footer2">
+                        
+
+  <li><a href="//www.data.gov/about">About</a></li>
+
+  <li><a href="//www.data.gov/open-gov/">Open Government</a></li>
+
+  <li><a href="///www.data.gov/privacy-policy">Website Policies</a></li>
+
+  <li><a href="//catalog.data.gov/sitemap.xml">Sitemap</a></li>
+
+  <li><a href="//www.performance.gov/">PERFORMANCE.GOV</a></li>
+ 
+                        <li><a href="/user/saml2login" class="local-link"> Login</a></li>
+                        
+                    </ul>
+                </div>
+                <div class="tablet:grid-col"></div>
+                <div class="tablet:grid-col">
+                    <ul class="add-list-reset">
+                        <li>
+                            <a href="https://twitter.com/usdatagov"><i class="fa fa-twitter"></i><span>Twitter</span></a>
+                        </li>
+                        <li>
+                            <a href="https://github.com/GSA/data.gov"><i class="fa fa-github"></i><span>Github</span></a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer> <div class="usa-identifier">
+    <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier,,,">
+        <div class="grid-container-widescreen">
+            <div class="usa-identifier__container">
+                <div class="usa-identifier__logos">
+                    <div class="usa-identifier__logo">
+                        <img class="usa-identifier__logo-img" alt="GSA logo" role="img"
+                            src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/gsa_starmark.png"/>
+                    </div>
+                </div>
+                <div class="usa-identifier__identity" aria-label="Agency description">
+                    <p class="usa-identifier__identity-domain">data.gov</p>
+                    <p class="usa-identifier__identity-disclaimer">An official website of the GSA's <a
+                        href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services"
+                        class="usa-identifier__required-link usa-link"
+                        >Technology Transformation Services</a>
+                        <svg class="usa-icon" aria-hidden="true" role="img">
+                            <use xlink:href="#svg-launch"></use>
+                            <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                        </svg>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+    <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Important links,,,">
+        <div class="usa-identifier__container">
+            <ul class="usa-identifier__required-links-list">
+                <li class="usa-identifier__required-links-item">
+                    <a href="https://www.gsa.gov/about-us" class="usa-identifier__required-link usa-link">About GSA</a>
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a
+                        href="https://www.gsa.gov/website-information/website-policies#accessibility"
+                        class="usa-identifier__required-link usa-link"
+                        >Accessibility support</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a
+                        href="https://www.gsa.gov/reference/freedom-of-information-act-foia"
+                        class="usa-identifier__required-link usa-link"
+                        >FOIA requests</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a
+                        href="https://www.gsa.gov/reference/civil-rights-programs/notification-and-federal-employee-antidiscrimination-and-retaliation-act-of-2002"
+                        class="usa-identifier__required-link usa-link"
+                        >No FEAR Act data</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a href="https://www.gsaig.gov" class="usa-identifier__required-link usa-link"
+                        >Office of the Inspector General</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a
+                        href="https://www.gsa.gov/reference/reports/budget-performance"
+                        class="usa-identifier__required-link usa-link"
+                        >Performance reports</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a
+                        href="https://www.gsa.gov/website-information/website-policies#privacy"
+                        class="usa-identifier__required-link usa-link"
+                        >Privacy policy</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+            </ul>
+        </div>
+    </nav>
+    <section
+        class="usa-identifier__section usa-identifier__section--usagov"
+        aria-label="U.S. government information and services,,,"
+    >
+        <div class="usa-identifier__container">
+            <div class="usa-identifier__usagov-description">Looking for U.S. government information and services?</div>
+            <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
+            <svg class="usa-icon" aria-hidden="true" role="img">
+                <use xlink:href="#svg-launch"></use>
+                <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+            </svg>
+        </div>
+    </section>
+</div> 
+
+    
+<link href="/static-assets/css/d05bf0e7_fontawesome.css" rel="stylesheet"/>
+<script src="/static-assets/js/8c3c143a_jquery.js" type="text/javascript"></script>
+<script src="/static-assets/js/extension.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/proxy/public/sitedown.html
+++ b/proxy/public/sitedown.html
@@ -1,0 +1,402 @@
+
+<!DOCTYPE html>
+<!--[if IE 9]> <html lang="en" class="ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en"  > <!--<![endif]-->
+  <head>
+      <meta name="generator" content="ckan 2.10.1" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>503 Site Temporarily Down</title>
+
+    
+    
+    <link rel="shortcut icon" href="/static-assets/images/favicon.ico" />
+    
+      
+      <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+    
+
+    
+    <link href="/static-assets/css/93c09e07_main.css" rel="stylesheet"/>
+<link href="/static-assets/css/datagovtheme.css" rel="stylesheet"/>
+    
+  </head>
+
+  
+  <body data-site-root="https://catalog.data.gov/" data-locale-root="https://catalog.data.gov/" >
+
+    
+    
+        
+    
+
+    
+    <div class="visually-hidden-focusable"><a href="#content">Skip to main content</a></div>
+  
+
+  
+    
+<section class="usa-banner" aria-label="Official government website">
+    <div class="usa-accordion">
+        <header class="usa-banner__header">
+            <div class="usa-banner__inner">
+                <div class="grid-col-auto">
+                    <img class="usa-banner__header-flag" src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/us_flag_small.png" alt="U.S. flag" />
+                </div>
+                <div class="grid-col-fill tablet:grid-col-auto">
+                    <p class="usa-banner__header-text">
+                        An official website of the United States government
+                    </p>
+                    <p class="usa-banner__header-action" aria-hidden="true">
+                        Here's how you know
+                    </p>
+                </div>
+                <button type="button" class="usa-accordion__button usa-banner__button" aria-expanded="false"
+                    aria-controls="gov-banner-default-default">
+                    <span class="usa-banner__button-text">Here's how you know</span>
+                </button>
+            </div>
+        </header>
+        <div class="usa-banner__content usa-accordion__content" id="gov-banner-default-default">
+            <script>document.getElementById('gov-banner-default-default').setAttribute('hidden', '');</script>
+            <div class="grid-row grid-gap-lg">
+                <div class="usa-banner__guidance tablet:grid-col-6">
+                    <img class="usa-banner__icon usa-media-block__img" src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/icon-dot-gov.svg" role="img"
+                        alt="" aria-hidden="true" />
+                    <div class="usa-media-block__body">
+                        <p>
+                            <strong>Official websites use .gov</strong><br />A
+                            <strong>.gov</strong> website belongs to an official government
+                            organization in the United States.
+                        </p>
+                    </div>
+                </div>
+                <div class="usa-banner__guidance tablet:grid-col-6">
+                    <img class="usa-banner__icon usa-media-block__img" src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/icon-https.svg" role="img"
+                        alt="" aria-hidden="true" />
+                    <div class="usa-media-block__body">
+                        <p>
+                            <strong>Secure .gov websites use HTTPS</strong><br />A
+                            <strong>lock</strong> (
+                            <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64"
+                                    viewBox="0 0 52 64" class="usa-banner__lock-image" role="img"
+                                    aria-labelledby="banner-lock-title-default banner-lock-description-default"
+                                    focusable="false">
+                                    <title id="banner-lock-title-default">Lock</title>
+                                    <desc id="banner-lock-description-default">A locked padlock</desc>
+                                    <path fill="#000000" fill-rule="evenodd"
+                                        d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z" />
+                                </svg> </span>) or <strong>https://</strong> means you’ve safely connected to
+                            the .gov website. Share sensitive information only on official,
+                            secure websites.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<a href="#content" class="hide">Skip to content</a>
+<section class="usa-header usa-header--extended" role="banner">
+    <div class="grid-container">
+        <div class="grid-row">
+            <div class="grid-col-fill desktop:grid-col-auto">
+                <div class="usa-navbar">
+                    <div class="usa-logo" id="extended-logo">
+                        <em class="usa-logo__text"><a href="https://data.gov" title="Home" aria-label="Home"></a></em>
+                    </div>
+
+                    <button class="usa-menu-btn">Menu</button>
+                </div>
+            </div>
+            <div class="grid-col-auto desktop:grid-col-fill">
+                <nav id="menu-navigation" aria-label="Menu navigation" role="navigation" class="usa-nav">
+                    <div class="usa-nav__inner">
+                        <button class="usa-nav__close">
+                            <img src="/static-assets/images/close.svg" alt="Close" />
+                        </button>
+                        
+                            
+                            
+                        
+                        <ul class="usa-nav__primary usa-accordion">
+                            <li class="usa-nav__primary-item">
+                                <a class="usa-nav__link usa-current" href="/"><span class="text-uppercase">Data</span></a>
+                            </li>
+                            <li class="usa-nav__primary-item">
+                                <a class="usa-nav__link " href="/report"><span class="text-uppercase">Reports</span></a>
+                            </li>
+                            <li class="usa-nav__primary-item">
+                                <a class="usa-nav__link" href="https://data.gov/open-gov/"><span class="text-uppercase">Open Government</span></a>
+                            </li>
+                            <li class="usa-nav__primary-item">
+                                <a class="usa-nav__link" href="https://data.gov/contact/"><span class="text-uppercase">Contact</span></a>
+                            </li>
+                            <li class="usa-nav__primary-item desktop-hide">
+                                <a class="usa-nav__link" href="https://data.gov/user-guide/"><span class="text-uppercase">User Guide</span></a>
+                            </li>
+                        </ul>
+                        <div class="usa-nav__secondary">
+                            <ul class="usa-nav__secondary-links">
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
+            </div>
+            <div class="grid-col-auto user-guide__col desktop-show text-center">
+                <a href="https://data.gov/user-guide/">
+                    <img src="/static-assets/images/user-guide.svg" alt="User Guide" />
+                    <div class="user-guide__text">User Guide</div>
+                </a>
+            </div>
+        </div>
+        <hgroup class="top">
+            
+            <div class="account-wrapper">
+                
+            </div>
+            
+        </hgroup>
+    </div>
+</section>
+
+
+
+<header class="navbar navbar-static-top masthead">
+    
+    <div class="header_new banner_new page-heading_new">
+        <div class="container">
+            <div class="page-header_new">
+                <div class="main-heading">
+                    <h1>
+                        Data Catalog
+                    </h1>
+                </div>
+
+                <div class="toolbar">
+                        
+                        <ol class="breadcrumb">
+                            <li class="home"><a href="/dataset/"><i class="fa fa-home"></i><span> Home</span></a></li>
+                            <li><a href="/dataset/">Datasets</a></li>
+                        </ol>
+                        
+                    <div class="add_action">
+                        <a href="/organization/" class="btn btn_new">Organizations</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>
+
+  
+    
+<div role="main" class="controller- action-">
+    
+      <div id="content" class="container">
+        
+          
+  
+  
+
+
+          
+            <div class="toolbar" role="navigation" aria-label="Breadcrumb">
+              
+
+            </div>
+          
+
+          <div class="row wrapper no-nav">
+            
+            
+            
+
+            
+
+            
+  <article class="module">
+    <div class="module-content">
+      
+      <h1>Site Temporarily Down</h1>
+      
+      We are currently experiencing unscheduled downtime on our website. 
+      <br><br>
+      We are aware of this issue and our team is working diligently to resolve it as quickly as possible. Please check back later.
+    </div>
+    
+    
+  
+  </article>
+
+          </div>
+        
+      </div>
+    </div>
+   <footer class="usa-footer site-footer" role="contentinfo">
+    <div class="footer-section-bottom bg-base-lighter">
+        <div class="grid-container">
+            <div class="grid-row padding-y-3">
+                <div class="tablet:grid-col-auto">
+                    <div class="logo-links">
+                        <a class="footer-logo media_link" href="https://data.gov">
+                            <img
+                                class="width-30 height-auto"
+                                src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/logo.png"
+                                alt="Data.gov logo"
+                            />
+                        </a>
+                    </div>
+                    <ul class="grid-row grid-gap" id="menu-footer2">
+                        
+
+  <li><a href="//www.data.gov/about">About</a></li>
+
+  <li><a href="//www.data.gov/open-gov/">Open Government</a></li>
+
+  <li><a href="///www.data.gov/privacy-policy">Website Policies</a></li>
+
+  <li><a href="//catalog.data.gov/sitemap.xml">Sitemap</a></li>
+
+  <li><a href="//www.performance.gov/">PERFORMANCE.GOV</a></li>
+ 
+                        <li><a href="/user/saml2login" class="local-link"> Login</a></li>
+                        
+                    </ul>
+                </div>
+                <div class="tablet:grid-col"></div>
+                <div class="tablet:grid-col">
+                    <ul class="add-list-reset">
+                        <li>
+                            <a href="https://twitter.com/usdatagov"><i class="fa fa-twitter"></i><span>Twitter</span></a>
+                        </li>
+                        <li>
+                            <a href="https://github.com/GSA/data.gov"><i class="fa fa-github"></i><span>Github</span></a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer> <div class="usa-identifier">
+    <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier,,,">
+        <div class="grid-container-widescreen">
+            <div class="usa-identifier__container">
+                <div class="usa-identifier__logos">
+                    <div class="usa-identifier__logo">
+                        <img class="usa-identifier__logo-img" alt="GSA logo" role="img"
+                            src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/gsa_starmark.png"/>
+                    </div>
+                </div>
+                <div class="usa-identifier__identity" aria-label="Agency description">
+                    <p class="usa-identifier__identity-domain">data.gov</p>
+                    <p class="usa-identifier__identity-disclaimer">An official website of the GSA's <a
+                        href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services"
+                        class="usa-identifier__required-link usa-link"
+                        >Technology Transformation Services</a>
+                        <svg class="usa-icon" aria-hidden="true" role="img">
+                            <use xlink:href="#svg-launch"></use>
+                            <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                        </svg>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+    <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Important links,,,">
+        <div class="usa-identifier__container">
+            <ul class="usa-identifier__required-links-list">
+                <li class="usa-identifier__required-links-item">
+                    <a href="https://www.gsa.gov/about-us" class="usa-identifier__required-link usa-link">About GSA</a>
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a
+                        href="https://www.gsa.gov/website-information/website-policies#accessibility"
+                        class="usa-identifier__required-link usa-link"
+                        >Accessibility support</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a
+                        href="https://www.gsa.gov/reference/freedom-of-information-act-foia"
+                        class="usa-identifier__required-link usa-link"
+                        >FOIA requests</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a
+                        href="https://www.gsa.gov/reference/civil-rights-programs/notification-and-federal-employee-antidiscrimination-and-retaliation-act-of-2002"
+                        class="usa-identifier__required-link usa-link"
+                        >No FEAR Act data</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a href="https://www.gsaig.gov" class="usa-identifier__required-link usa-link"
+                        >Office of the Inspector General</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a
+                        href="https://www.gsa.gov/reference/reports/budget-performance"
+                        class="usa-identifier__required-link usa-link"
+                        >Performance reports</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+                <li class="usa-identifier__required-links-item">
+                    <a
+                        href="https://www.gsa.gov/website-information/website-policies#privacy"
+                        class="usa-identifier__required-link usa-link"
+                        >Privacy policy</a
+                    >
+                    <svg class="usa-icon" aria-hidden="true" role="img">
+                        <use xlink:href="#svg-launch"></use>
+                        <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+                    </svg>
+                </li>
+            </ul>
+        </div>
+    </nav>
+    <section
+        class="usa-identifier__section usa-identifier__section--usagov"
+        aria-label="U.S. government information and services,,,"
+    >
+        <div class="usa-identifier__container">
+            <div class="usa-identifier__usagov-description">Looking for U.S. government information and services?</div>
+            <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
+            <svg class="usa-icon" aria-hidden="true" role="img">
+                <use xlink:href="#svg-launch"></use>
+                <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+            </svg>
+        </div>
+    </section>
+</div> 
+
+    
+<link href="/static-assets/css/d05bf0e7_fontawesome.css" rel="stylesheet"/>
+<script src="/static-assets/js/8c3c143a_jquery.js" type="text/javascript"></script>
+<script src="/static-assets/js/extension.js" type="text/javascript"></script>
+  </body>
+</html>


### PR DESCRIPTION
Part of 
- https://github.com/GSA/data.gov/issues/3907

Changes
- looking for `CATALOG_WEB_MODE` and `CATALOG_ADMIN_MODE` env vars to decide operation mode
- return 503 for down time
- add maintenance.html and sitedown.html
- 503 error was set with short cache time on cloudfront to minimize maintenance hangover. 

TODO:
make a github action. before that happens, we can use 'cf set-env' command.