### PR TITLE
 add github action for maintenance mode

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,64 @@
+---
+name: 8 - Maintenance Mode
+
+on:
+  workflow_dispatch:
+    inputs:
+      environ:
+        description: 'Environment:'
+        required: true
+        type: choice
+        options:
+          - development
+          - staging
+          - prod
+      app:
+        description: 'Catalog App:'
+        required: true
+        type: choice
+        options:
+          - catalog-web
+          - catalog-admin
+          - both
+      mode:
+        description: 'Operation Mode:'
+        required: true
+        type: choice
+        options:
+          - Normal
+          - Scheduled_Maintenance
+          - Unscheduled_Downtime
+      notification:
+        description: 'Notification to Slack?'
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  set-maintenance-mode:
+    name: Set ${{inputs.environ}}:${{inputs.app}} to ${{inputs.mode}}
+    runs-on: ubuntu-latest
+    environment: ${{inputs.environ}}
+    steps:
+      - name: checkout datagov
+        uses: actions/checkout@v3
+        with:
+          path: './catalog'
+      - name: run task
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: catalog/tools/set_maintenance.sh ${{inputs.app}} ${{inputs.mode}}
+          cf_org: gsa-datagov
+          cf_space: ${{ inputs.environ }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: Send notification to Slack
+        if: ${{ inputs.notification }}
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "${{inputs.app}} catalog app in ${{inputs.environ}} space is now in ${{inputs.mode}} mode."
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/tools/set_maintenance.sh
+++ b/tools/set_maintenance.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# write usage
+function usage {
+  echo "Usage: $0 catalog_app_name maintenance_mode"
+  exit 1
+}
+
+if [ $# -ne 2 ] ; then
+    usage
+fi
+
+# get mode value from maintenance_mode
+case "$2" in
+    "Scheduled_Maintenance")
+        maintenance_mode="MAINTENANCE"
+        ;;
+    "Unscheduled_Downtime")
+        maintenance_mode="DOWN"
+        ;;
+    *)
+        maintenance_mode="NORMAL"
+        ;;
+esac
+
+# set for catalog-web
+if [ "$1" == "catalog-web" ] || [ "$1" == "both" ] ; then
+    # compare with existing env value, run cf set-env only if it's different or not set
+    current_mode=$(cf env catalog-proxy | grep CATALOG_WEB_MODE | awk '{print $2}')
+    if [ "$current_mode" != "$maintenance_mode" ] ; then
+        cf set-env catalog-proxy CATALOG_WEB_MODE $maintenance_mode
+        need_restart=true
+    fi
+fi
+
+# set for catalog-admin
+if [ "$1" == "catalog-admin" ] || [ "$1" == "both" ] ; then
+    # compare with existing env value, run cf set-env only if it's different or not set
+    current_mode=$(cf env catalog-proxy | grep CATALOG_ADMIN_MODE | awk '{print $2}')
+    if [ "$current_mode" != "$maintenance_mode" ] ; then
+        cf set-env catalog-proxy CATALOG_ADMIN_MODE $maintenance_mode
+        need_restart=true
+    fi
+fi
+
+# restart catalog-proxy if needed
+if [ "$need_restart" == "true" ] ; then
+    cf restart catalog-proxy --strategy rolling
+fi


### PR DESCRIPTION
This is last part of 
- https://github.com/GSA/data.gov/issues/3907

Changes:
added github action to manage catalog-web and catalog-admin maintenance mode

TODO:
set secrets.SLACK_WEBHOOK_URL in github to have incoming notifications to datagov-alerts channel.  