### PR TITLE
Make proxy instance count variable

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -70,6 +70,7 @@ applications:
     path: ./proxy
     # TODO: tweak with load testing
     memory: 100M
+    instances: ((proxy-instances))
     routes:
       - route: ((route-external))
       - route: ((route-external-admin))

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -9,6 +9,7 @@ web-instances: 1
 admin-instances: 1
 gather-instances: 1
 fetch-instances: 1
+proxy-instances: 1
 memory_quota: 750M
 gather_memory_quota: 1G
 

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -9,6 +9,7 @@ web-instances: 5
 admin-instances: 1
 gather-instances: 1
 fetch-instances: 4
+proxy-instances: 2
 memory_quota: 850M
 gather_memory_quota: 3G
 

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -9,6 +9,7 @@ web-instances: 2
 admin-instances: 1
 gather-instances: 0
 fetch-instances: 0
+proxy-instances: 1
 memory_quota: 850M
 gather_memory_quota: 3G
 


### PR DESCRIPTION
Make production release have 2 instances; saw production go down with out of memory and 2 is best practice: https://cloud.gov/docs/deployment/production-ready/#more-than-one-instance