### PR TITLE
init ckan and report db

### DIFF
--- a/.profile
+++ b/.profile
@@ -163,9 +163,10 @@ echo Running ckan setup commands
 
 if [[ $MIGRATE_DB = 'True' ]]; then
   # Run migrations
+  ckan db init
   ckan db upgrade
   ckan harvester initdb
+  ckan report initdb
   # ckan archiver init
-  # ckan report initdb
   # ckan qa init
 fi


### PR DESCRIPTION
After bound to a fresh db, ckan app failed to start, error in report generation. We need to add the idempotent db init commands
- `ckan db init`
- `ckan report initdb` 