### PR TITLE
Add exceptions in snyk ignore

### DIFF
--- a/ckan/.snyk
+++ b/ckan/.snyk
@@ -3,52 +3,66 @@ version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-PYTHON-BEAKER-575115:
-    - "*":
+    - '*':
         reason: >-
           No remediation available yet; Not affecting us since the storage is
           not accessible to any other client
         expires: 2024-05-31T16:20:58.017Z
         created: 2022-12-08T16:20:58.023Z
   SNYK-PYTHON-WERKZEUG-6035177:
-    - "*":
+    - '*':
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4217
         expires: 2024-05-31T16:20:58.017Z
         created: 2023-10-30T16:50:58.023Z
   SNYK-PYTHON-WERKZEUG-3319936:
-    - "*":
+    - '*':
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4217
         expires: 2024-05-31T16:20:58.017Z
         created: 2023-02-15T16:20:58.023Z
   SNYK-PYTHON-WERKZEUG-3319935:
-    - "*":
+    - '*':
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4217
         expires: 2024-05-31T16:20:58.017Z
         created: 2023-02-15T16:20:58.023Z
   SNYK-PYTHON-FLASK-5490129:
-    - "*":
+    - '*':
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4303
         expires: 2024-05-31T16:20:58.017Z
         created: 2023-05-08T16:20:58.023Z
   SNYK-PYTHON-PYOPENSSL-6149520:
-    - "*":
+    - '*':
         reason: >-
           No remediation available yet; Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4532
         expires: 2024-05-31T19:29:54.032Z
         created: 2024-01-08T00:00:00.000Z
   SNYK-PYTHON-PYOPENSSL-6157250:
-    - "*":
+    - '*':
         reason: >-
           No remediation available yet; Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4591
         expires: 2024-05-31T19:29:54.032Z
         created: 2024-01-14T00:00:00.000Z
+  SNYK-PYTHON-CRYPTOGRAPHY-6592767:
+    - '*':
+        reason: >-
+          No remediation available yet; Issue tracked in github:
+          https://github.com/GSA/data.gov/issues/4532
+        expires: 2024-10-24T17:21:30.083Z
+        created: 2024-04-24T17:21:30.089Z
+  SNYK-PYTHON-PYOPENSSL-6592766:
+    - '*':
+        reason: >-
+          No remediation available yet; Issue tracked in github:
+          https://github.com/GSA/data.gov/issues/4591
+        expires: 2024-10-24T17:24:47.251Z
+        created: 2024-04-24T17:24:47.257Z
 patch: {}


### PR DESCRIPTION
added two low severity exceptions to the ignore list to fix the snyk test error. 
https://github.com/GSA/data.gov/issues/4705