### PR TITLE
pin flask_debugtoolbar

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -41,7 +41,8 @@ COPY setup/who.ini ${APP_DIR}/
 COPY saml2 ${APP_DIR}/saml2
 
 # Install dev dependencies
-RUN pip3 install flask_debugtoolbar
+# pin to 0.14.1
+RUN pip3 install flask_debugtoolbar==0.14.1
 
 # In order for dependencies to be managed, python
 # needs to be mapped to python3


### PR DESCRIPTION
Related to:
- https://github.com/GSA/data.gov/issues/4721

Flask-DebugToolbar released 0.15.0 and 0.15.1 within the past week that broke the catalog ckan.
- https://pypi.org/project/Flask-DebugToolbar/#history

 