### PR TITLE
update snyk severity threshold

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           # Run scan
           snyk auth ${{ secrets.SNYK_TOKEN }}
-          snyk test --file=ckan/requirements.txt --json-file-output=scan.json || echo "Scan complete"
+          snyk test --severity-threshold=medium --file=ckan/requirements.txt --json-file-output=scan.json || echo "Scan complete"
 
           # Exit if no vulnerabilities
           # Succeed, so that PR is NOT created


### PR DESCRIPTION
low severity [issue](https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6913422) causes scan to fail in catalog and inventory actions. updating snyk test to ignore low severity issues. 