### PR TITLE
update datagovtheme to use js_recent_view

### DIFF
--- a/.env
+++ b/.env
@@ -167,6 +167,9 @@ CKANEXT__SAML2AUTH__REQUESTED_AUTHN_CONTEXT_COMPARISON=exact
 # Avoid double package_show call to add tracking info
 CKANEXT__DATAGOVCATALOG__ADD_PACKAGES_TRACKING_INFO=false
 
+# Render recent view using AJAX call to boost page loading speed
+CKANEXT__DATAGOVTHEME__JS_RECENT_VIEW=true
+
 # Remove all translated pages, for less crawling
 CKAN__LOCALES_FILTERED_OUT=am ar bg bs ca cs_CZ da_DK de el en_AU en_GB es es_AR eu fa_IR fi fr gl he hr hu id is it ja km ko_KR lt lv mk mn_MN my_MM nb_NO ne nl no pl pt_BR pt_PT ro ru sk sl sq sr sr_Latn sv th tl tr uk uk_UA vi zh_Hans_CN zh_Hant_TW
 

--- a/.profile
+++ b/.profile
@@ -135,6 +135,12 @@ export CKANEXT__S3SITEMAP__AWS_BUCKET_NAME=$(vcap_get_service s3 .credentials.bu
 export CKANEXT__S3SITEMAP__AWS_STORAGE_PATH=catalog/sitemap
 export CKANEXT__S3SITEMAP__ENDPOINT_URL=https://$(vcap_get_service s3 .credentials.endpoint)
 
+# Disable this in favor of CKANEXT__DATAGOVTHEME__JS_RECENT_VIEW
+export CKANEXT__DATAGOVCATALOG__ADD_PACKAGES_TRACKING_INFO=false
+
+# Render recent view using AJAX call to boost page loading speed
+export CKANEXT__DATAGOVTHEME__JS_RECENT_VIEW=true
+
 # Set up the collection in Solr
 echo Setting up Solr collection
 export SOLR_COLLECTION=ckan

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.3.2
 ckan @ git+https://github.com/GSA/ckan.git@7159a872ba740069b768fcd2a43cde81a57ee492
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.0
-ckanext-datagovtheme==0.2.25
+ckanext-datagovtheme==0.2.26
 ckanext-datajson==0.1.25
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@83495ba99cba17398ba8feb1bc0da486f3798584
 ckanext-envvars==0.0.3

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.3.2
 ckan @ git+https://github.com/GSA/ckan.git@7159a872ba740069b768fcd2a43cde81a57ee492
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.0
-ckanext-datagovtheme==0.2.24
+ckanext-datagovtheme==0.2.25
 ckanext-datajson==0.1.25
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@83495ba99cba17398ba8feb1bc0da486f3798584
 ckanext-envvars==0.0.3

--- a/e2e/cypress/integration/main_page.cy.js
+++ b/e2e/cypress/integration/main_page.cy.js
@@ -1,7 +1,7 @@
 describe('Main Page', () => {
     it('Redirects from / to /dataset', () => {
         cy.visit('/');
-        cy.url().should('be.equal', `${Cypress.config('baseUrl')}/dataset`);
+        cy.url().should('be.equal', `${Cypress.config('baseUrl')}/dataset/`);
     });
 
     it('Load main page with configuration', () => {


### PR DESCRIPTION
Bring changes from https://github.com/GSA/ckanext-datagovtheme/pull/199 for https://github.com/GSA/data.gov/issues/4708.

- set `ckanext.datagovcatalog.add_package_tracking_info=false`
- set `ckanext.datagovtheme.js_recent_view=true`
