### PR TITLE
Catalog fetch command

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.3.2
 ckan @ git+https://github.com/GSA/ckan.git@7159a872ba740069b768fcd2a43cde81a57ee492
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.0
-ckanext-datagovtheme==0.2.27
+ckanext-datagovtheme==0.2.28
 ckanext-datajson==0.1.25
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@83495ba99cba17398ba8feb1bc0da486f3798584
 ckanext-envvars==0.0.3

--- a/manifest.yml
+++ b/manifest.yml
@@ -122,7 +122,7 @@ applications:
     no-route: true
     instances: ((fetch-instances))
     disk_quota: 1.5G
-    command: newrelic-admin run-program ckan harvester fetch-consumer
+    command: newrelic-admin run-program sh -c 'while ! ckan harvester fetch-consumer; do sleep 10; done'
     health-check-type: process
     timeout: 15
     env:


### PR DESCRIPTION
Retry https://github.com/GSA/catalog.data.gov/pull/606.

Related to 
- https://github.com/GSA/data.gov/issues/4775
- https://github.com/GSA/data.gov/issues/4223

By putting fetch-consumer command in a while loop, it the command crash, it wont bring down the whole catalog-fetch instance.