### PR TITLE
extended the snyk exception date

### DIFF
--- a/ckan/.snyk
+++ b/ckan/.snyk
@@ -67,17 +67,17 @@ ignore:
     - '*':
         reason: >-
            Not affecting us since no debugger is enabled in cloud.gov apps
-        expires: 2024-06-31T16:20:58.017Z
+        expires: 2024-09-30T16:20:58.017Z
   SNYK-PYTHON-CRYPTOGRAPHY-7161587:
     - '*':
         reason: >-
            No remediation available yet. Issue tracked in github:
            https://github.com/GSA/data.gov/issues/4781
-        expires: 2024-06-31T16:20:58.017Z
+        expires: 2024-09-30T16:20:58.017Z
   SNYK-PYTHON-PYOPENSSL-7161590:
     - '*':
         reason: >-
            No remediation available yet. Issue tracked in github:
            https://github.com/GSA/data.gov/issues/4782
-        expires: 2024-06-31T16:20:58.017Z
+        expires: 2024-09-30T16:20:58.017Z
 patch: {}


### PR DESCRIPTION
extended the date for snyk exceptions which not be accepted in CKAN 2.10 yet. 

Related to https://github.com/GSA/data.gov/issues/4803