### PR TITLE
bump theme for 4743

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.3.2
 ckan @ git+https://github.com/GSA/ckan.git@7159a872ba740069b768fcd2a43cde81a57ee492
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.0
-ckanext-datagovtheme==0.2.28
+ckanext-datagovtheme==0.2.29
 ckanext-datajson==0.1.25
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@83495ba99cba17398ba8feb1bc0da486f3798584
 ckanext-envvars==0.0.3


### PR DESCRIPTION
Merge after https://github.com/GSA/ckanext-datagovtheme/pull/204

Related to https://github.com/GSA/data.gov/issues/4743. 

I thought I had made the PR for this a week ago, but aparently just did the [blocking PR](https://github.com/GSA/data.gov/pull/4802) and never this one. 