### PR TITLE
temporarily disable staging restart for debugging

### DIFF
--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -7,14 +7,6 @@ on:
     - cron: '11/30 * * * *'
 
 jobs:
-  restart-staging:
-    name: restart (staging)
-    uses: gsa/data.gov/.github/workflows/app-restart-template.yml@main
-    with:
-      environ: staging
-      app_names: "{\"include\":[{\"app\":\"catalog-proxy\"},{\"app\":\"catalog-gather\"},{\"app\":\"catalog-fetch\"},{\"app\":\"catalog-web\"},{\"app\":\"catalog-admin\"},]}"
-    secrets: inherit
-
   restart-prod:
     name: restart (prod)
     uses: gsa/data.gov/.github/workflows/app-restart-template.yml@main


### PR DESCRIPTION
Temporarily stop staging restart to debug catalog-gather/catalog-fetch stuck issue, as noted in https://github.com/GSA/data.gov/issues/4864#issuecomment-2312788002