### PR TITLE
Revert "temporarily disable staging restart for debugging"

### DIFF
--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -7,6 +7,14 @@ on:
     - cron: '11/30 * * * *'
 
 jobs:
+  restart-staging:
+    name: restart (staging)
+    uses: gsa/data.gov/.github/workflows/app-restart-template.yml@main
+    with:
+      environ: staging
+      app_names: "{\"include\":[{\"app\":\"catalog-proxy\"},{\"app\":\"catalog-gather\"},{\"app\":\"catalog-fetch\"},{\"app\":\"catalog-web\"},{\"app\":\"catalog-admin\"},]}"
+    secrets: inherit
+
   restart-prod:
     name: restart (prod)
     uses: gsa/data.gov/.github/workflows/app-restart-template.yml@main


### PR DESCRIPTION
This reverts the temporary debugging commit 7020bff4eb65f742df1e355fbf245f8342d8c23b in https://github.com/GSA/catalog.data.gov/pull/1437.