### PR TITLE
keep facebook out of tracking stats

### DIFF
--- a/proxy/nginx-goodbot200.conf
+++ b/proxy/nginx-goodbot200.conf
@@ -1,10 +1,11 @@
-# prevent top 6 bots from entering data into /_tracking
+# prevent top 7 bots from entering data into /_tracking
 ## Googlebot/
 ## Y!J
 ## Yeti
 ## Bytespider
 ## Applebot
 ## HeadlessChrome
+## facebookexternalhit and developers.facebook.com
 
 set $botstracking 0;
 
@@ -12,7 +13,7 @@ if ($uri = "/_tracking") {
   set $botstracking 1;
 }
 
-if ($http_user_agent ~ 'Googlebot/|Y!J|Yeti|Bytespider|Applebot|HeadlessChrome') {
+if ($http_user_agent ~ 'Googlebot/|Y!J|Yeti|Bytespider|Applebot|HeadlessChrome|facebook') {
   set $botstracking "${botstracking}1";
 }
 


### PR DESCRIPTION
NewRelic dashboard shows facebook bots are parsing JS and accessing /_tracking. To keep _tracking targeted for end user traffic only, we want to ignore facebook traffic. 

![image](https://github.com/user-attachments/assets/a8e27c6a-dcd2-432c-ba97-e6eb6910eb72)
