### PR TITLE
update ckanext-datajson for max_resource_count

### DIFF
--- a/.env
+++ b/.env
@@ -170,6 +170,9 @@ CKANEXT__DATAGOVCATALOG__ADD_PACKAGES_TRACKING_INFO=false
 # Render recent view using AJAX call to boost page loading speed
 CKANEXT__DATAGOVTHEME__JS_RECENT_VIEW=true
 
+# Max number of resources to be allowed in a dataset to be harvested
+CKANEXT__DATAJSON__MAX_RESOURCE_COUNT=1500
+
 # Remove all translated pages, for less crawling
 CKAN__LOCALES_FILTERED_OUT=am ar bg bs ca cs_CZ da_DK de el en_AU en_GB es es_AR eu fa_IR fi fr gl he hr hu id is it ja km ko_KR lt lv mk mn_MN my_MM nb_NO ne nl no pl pt_BR pt_PT ro ru sk sl sq sr sr_Latn sv th tl tr uk uk_UA vi zh_Hans_CN zh_Hant_TW
 

--- a/.profile
+++ b/.profile
@@ -141,6 +141,9 @@ export CKANEXT__DATAGOVCATALOG__ADD_PACKAGES_TRACKING_INFO=false
 # Render recent view using AJAX call to boost page loading speed
 export CKANEXT__DATAGOVTHEME__JS_RECENT_VIEW=true
 
+# Max number of resources to be allowed in a dataset to be harvested
+export CKANEXT__DATAJSON__MAX_RESOURCE_COUNT=1500
+
 # Set up the collection in Solr
 echo Setting up Solr collection
 export SOLR_COLLECTION=ckan

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -14,7 +14,7 @@ ckan @ git+https://github.com/GSA/ckan.git@8c4a517efeac80db098cc6ba144cb742bbeca
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.0
 ckanext-datagovtheme==0.2.34
-ckanext-datajson==0.1.26
+ckanext-datajson==0.1.27
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@b8ebf24004cd3f3edb7f9d01c87c20259c102093
 ckanext-envvars==0.0.3
 ckanext-geodatagov==0.2.9

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -14,7 +14,7 @@ ckan @ git+https://github.com/GSA/ckan.git@8c4a517efeac80db098cc6ba144cb742bbeca
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.0
 ckanext-datagovtheme==0.2.34
-ckanext-datajson==0.1.25
+ckanext-datajson==0.1.26
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@b8ebf24004cd3f3edb7f9d01c87c20259c102093
 ckanext-envvars==0.0.3
 ckanext-geodatagov==0.2.9


### PR DESCRIPTION
Bring changes from
- https://github.com/GSA/ckanext-datajson/pull/158
- https://github.com/GSA/ckanext-datajson/pull/159

Set optional config `ckanext.datajson.max_resource_count` to be 1500.