### PR TITLE
Resume prod scheduled activity

### DIFF
--- a/.github/workflows/ckan_auto.yml
+++ b/.github/workflows/ckan_auto.yml
@@ -58,7 +58,7 @@ jobs:
             "schedule": ["${{env.SCHEDULE_TRACKING}}", "${{env.SCHEDULE_SITEMAP}}",
                          "${{env.SCHEDULE_HARVESTING}}", "${{env.SCHEDULE_STUCK_JOBS}}",
                          "${{env.SCHEDULE_DBSOLR_SYNC}}", "${{ env.SCHEDULE_GEN_REPORT}}"],
-            "environ": ["development", "staging"],
+            "environ": ["development", "staging", "prod"],
             "include": [ {"app": "catalog-admin"},
                          {"error_seconds": 22000},
                          {"info_issue": false},


### PR DESCRIPTION
This reverts commit 6678ebe0fd1f83c0dc996374309ad6d2378b91a5.
This is will put `prod` back into the auto GitHub action matrix and resume all the scheduled activities. 