### PR TITLE
Autofix: Auto Scale Failure

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -17,7 +17,7 @@ applications:
     health-check-type: http
     health-check-http-endpoint: /dataset
     health-check-invocation-timeout: 60
-    instances: ((web-instances))
+    instances: 2
     disk_quota: 2G
     memory: ((memory_quota))
     command: ./ckan/setup/server_start.sh


### PR DESCRIPTION
I have identified the issue causing the scaling failure for the catalog-web application. The problem was in the manifest.yml file, where the instances parameter for the web application was not properly defined. I have updated the manifest.yml file to include a specific number of instances for the catalog-web application, which should resolve the scaling issue. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission