### PR TITLE
update dependencies

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -7,12 +7,11 @@ git+https://github.com/GSA/ckanext-saml2auth.git@datagov#egg=ckanext-saml2auth
 # -e git+https://github.com/ckan/ckanext-qa.git@master#egg=ckanext-qa
 -e git+https://github.com/ckan/ckanext-archiver.git@master#egg=ckanext-archiver
 -e git+https://github.com/ckan/ckanext-report.git@master#egg=ckanext-report
-
 -e git+https://github.com/GSA/ckanext-datagovcatalog.git@harvest-next#egg=ckanext_datagovcatalog
 -e git+https://github.com/GSA/ckanext-datagovtheme.git@harvest-next#egg=ckanext_datagovtheme
+-e git+https://github.com/GSA/ckanext-geodatagov.git@harvest-next#egg=ckanext_geodatagov
 ckanext-datajson
 ckanext-envvars>=0.0.3
-ckanext-geodatagov
 ckanext-metrics-dashboard
 
 # Pin for saml2auth to work

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -17,7 +17,7 @@ ckan @ git+https://github.com/GSA/ckan.git@8c4a517efeac80db098cc6ba144cb742bbeca
 ckanext-datajson==0.1.25
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@b8ebf24004cd3f3edb7f9d01c87c20259c102093
 ckanext-envvars==0.0.3
-ckanext-geodatagov==0.2.9
+-e git+https://github.com/GSA/ckanext-geodatagov.git@harvest-next#egg=ckanext_geodatagov
 -e git+https://github.com/GSA/ckanext-harvest.git@9039e7a5d563a40177d62487758b366ab77434b6#egg=ckanext_harvest
 ckanext-metrics-dashboard==0.1.6
 -e git+https://github.com/ckan/ckanext-report.git@3588577f46d17e5f6ef163bb984d0e7016daef71#egg=ckanext_report


### PR DESCRIPTION
Use branch name `harvest-next`, not  main/tag/commit, for extensions `datagovtheme` and `geodatagov` dependencies until things are settling down.

The new branch `harvest-next` was created for `geodatagov` for the new way to handle collection datasets.
- https://github.com/GSA/ckanext-geodatagov/commits/harvest-next/

Related to story https://github.com/GSA/data.gov/issues/4970