### PR TITLE
fix efs util build error by pinning to v2.1.0

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -11,7 +11,7 @@ USER root
 RUN apt-get update && apt-get install -y curl vim stunnel4 git
 
 # Install EFS Dependencies
-RUN git clone https://github.com/aws/efs-utils && \
+RUN git clone --depth 1 --branch v2.1.0 https://github.com/aws/efs-utils && \
   cd efs-utils && \
   apt-get -y install binutils rustc cargo pkg-config libssl-dev && \
   ./build-deb.sh && \


### PR DESCRIPTION
pin efs-utils to v2.1.0 to resolve build errors seen in https://github.com/GSA/catalog.data.gov/actions/runs/11937113325

```
./build-deb.sh: 53: envsubst: not found
```

