### PR TITLE
Suppress snyk warnings for unpatched vulns & bump datagovtheme

### DIFF
--- a/ckan/.snyk
+++ b/ckan/.snyk
@@ -28,7 +28,7 @@ ignore:
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4217
-        expires: 2024-11-30T19:29:54.032Z
+        expires: 2025-02-28T19:29:54.032Z
         created: 2023-02-15T16:20:58.023Z
   SNYK-PYTHON-FLASK-5490129:
     - '*':
@@ -55,7 +55,7 @@ ignore:
     - '*':
         reason: >-
           No remediation available yet; Low severity.
-        expires: 2024-11-30T17:24:47.251Z
+        expires: 2025-02-28T19:29:54.032Z
         created: 2024-04-24T17:24:47.257Z
   SNYK-PYTHON-WERKZEUG-6808933:
     - '*':

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.4.0
 ckan @ git+https://github.com/GSA/ckan.git@8c4a517efeac80db098cc6ba144cb742bbeca194
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.1
-ckanext-datagovtheme==0.2.37
+ckanext-datagovtheme==0.2.40
 ckanext-datajson==0.1.27
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@b8ebf24004cd3f3edb7f9d01c87c20259c102093
 ckanext-envvars==0.0.6


### PR DESCRIPTION
This should silence the SNYK PRs on those things we know are blocked by CKAN 2.11.0

Related to:
- https://github.com/GSA/data.gov/issues/4861