### PR TITLE
Snyk fix jinja version

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -47,7 +47,7 @@ idna==3.10
 importlib-resources==5.13.0
 isodate==0.7.2
 itsdangerous==2.2.0
-Jinja2==3.1.5
+Jinja2==3.1.4
 jmespath==1.0.1
 json-table-schema==0.2.1
 jsonschema==2.4.0

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -47,7 +47,7 @@ idna==3.10
 importlib-resources==5.13.0
 isodate==0.7.2
 itsdangerous==2.2.0
-Jinja2==3.1.4
+Jinja2==3.1.5
 jmespath==1.0.1
 json-table-schema==0.2.1
 jsonschema==2.4.0

--- a/tools/harvest_source_import/tests/test_import_DOI.py
+++ b/tools/harvest_source_import/tests/test_import_DOI.py
@@ -2,7 +2,6 @@ import json
 import pytest
 from remote_ckan.lib import RemoteCKAN
 
-
 @pytest.mark.vcr()
 def test_load_from_name():
     """ Test source using force_all config. """


### PR DESCRIPTION
Upgrade jinja2@3.1.4 to jinja2@3.1.5 to fix
  ✗ Template Injection (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181] in jinja2@3.1.4
    introduced by jinja2@3.1.4 and 6 other path(s)
  ✗ Improper Neutralization (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-85[48](https://github.com/GSA/catalog.data.gov/actions/runs/12559387427/job/35015078743#step:6:49)987] in jinja2@3.1.4
    introduced by jinja2@3.1.4 and 6 other path(s)