### PR TITLE
upgrade jinja version to 3.1.5

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -118,7 +118,7 @@ requests~=2.32.3
 
 # avoid ImportError error https://github.com/GSA/data.gov/issues/4396
 importlib-resources<6.0
-jinja2>=3.1.4
+jinja2>=3.1.5
 cryptography>=42.0.4
 
 # fix for https://security.snyk.io/vuln/SNYK-PYTHON-GEVENT-8320934

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -4,12 +4,12 @@ Babel==2.10.3
 Beaker==1.11.0
 bleach==5.0.1
 blinker==1.5
-boto3==1.35.76
-botocore==1.35.76
-certifi==2024.8.30
+boto3==1.35.90
+botocore==1.35.90
+certifi==2024.12.14
 cffi==1.17.1
 chardet==5.2.0
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
 ckan @ git+https://github.com/GSA/ckan.git@8c4a517efeac80db098cc6ba144cb742bbeca194
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.1
@@ -28,7 +28,7 @@ click==8.1.3
 cryptography==44.0.0
 defusedxml==0.7.1
 dominate==2.7.0
-elementpath==4.6.0
+elementpath==4.7.0
 feedgen==0.9.0
 Flask==2.0.3
 Flask-Babel==1.0.0
@@ -52,13 +52,13 @@ jmespath==1.0.1
 json-table-schema==0.2.1
 jsonschema==2.4.0
 lxml==5.1.0
-Mako==1.3.7
+Mako==1.3.8
 Markdown==3.4.1
 MarkupSafe==2.1.5
 messytables==0.15.2
 mypy==1.10.1
 mypy-extensions==1.0.0
-newrelic==10.3.1
+newrelic==10.4.0
 nose==1.3.7
 numpy==1.26.4
 OWSLib==0.32.0
@@ -87,7 +87,7 @@ PyUtilib==6.0.0
 PyYAML==6.0.1
 PyZ3950 @ git+https://github.com/danizen/PyZ3950@6d44a4ab85c8bda3a7542c2c9efdfad46c830219
 rdflib==6.1.1
-redis==5.2.0
+redis==5.2.1
 requests==2.32.3
 rfc3987==1.3.8
 rq==1.11.0
@@ -104,7 +104,7 @@ tomli==2.2.1
 typing_extensions==4.3.0
 tzdata==2024.2
 tzlocal==4.2
-urllib3==2.2.3
+urllib3==2.3.0
 watchdog==6.0.0
 webassets==2.0
 webencodings==0.5.1

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -47,7 +47,7 @@ idna==3.10
 importlib-resources==5.13.0
 isodate==0.7.2
 itsdangerous==2.2.0
-Jinja2==3.1.4
+Jinja2==3.1.5
 jmespath==1.0.1
 json-table-schema==0.2.1
 jsonschema==2.4.0


### PR DESCRIPTION
Upgrade jinja2@3.1.4 to jinja2@3.1.5 to fix
✗ Template Injection (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181] in jinja2@3.1.4
introduced by jinja2@3.1.4 and 6 other path(s)
✗ Improper Neutralization (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-85[48](https://github.com/GSA/catalog.data.gov/actions/runs/12559387427/job/35015078743#step:6:49)987] in jinja2@3.1.4
introduced by jinja2@3.1.4 and 6 other path(s)

related https://github.com/GSA/data.gov/issues/5023