### PR TITLE
apt dist-upgrade

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -8,7 +8,7 @@ USER root
 #######################
 
 # Add curl to access API routes
-RUN apt-get update && apt dist-upgrade -y && apt-get install -y curl vim stunnel4 git
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y curl vim stunnel4 git
 
 # Install EFS Dependencies
 RUN apt-get -y install binutils rustc cargo pkg-config libssl-dev

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -8,14 +8,12 @@ USER root
 #######################
 
 # Add curl to access API routes
-RUN apt-get update && apt-get install -y curl vim stunnel4 git
+RUN apt-get update && apt dist-upgrade -y && apt-get install -y curl vim stunnel4 git
 
 # Install EFS Dependencies
-RUN git clone --depth 1 --branch v2.1.0 https://github.com/aws/efs-utils && \
-  cd efs-utils && \
-  apt-get -y install binutils rustc cargo pkg-config libssl-dev && \
-  ./build-deb.sh && \
-  apt-get -y install ./build/amazon-efs-utils*deb
+RUN apt-get -y install binutils rustc cargo pkg-config libssl-dev
+RUN git clone --depth 1 --branch v2.1.0 https://github.com/aws/efs-utils
+RUN cd efs-utils && ./build-deb.sh && apt-get -y install ./build/amazon-efs-utils*deb
 
 # Install hostname resolution dependencies
 RUN apt-get install -y dnsutils


### PR DESCRIPTION
Start to see error when run `make build`. 
```
1.726 Err:2 http://security.ubuntu.com/ubuntu focal-updates/main amd64 libglib2.0-0 amd64 2.64.6-1~ubuntu20.04.7
1.726   404  Not Found [IP: 91.189.91.81 80]
1.845 Err:3 http://security.ubuntu.com/ubuntu focal-updates/main amd64 libglib2.0-data all 2.64.6-1~ubuntu20.04.7
1.845   404  Not Found [IP: 91.189.91.81 80]
```
- added `dist-upgrade -y` to fix the error on this old ubuntu package
- refactor `Install EFS Dependencies` long commands