### PR TITLE
retry in cypress

### DIFF
--- a/e2e/cypress.config.js
+++ b/e2e/cypress.config.js
@@ -8,4 +8,8 @@ module.exports = defineConfig({
     videoCompression: false,
     videoUploadOnPasses: false,
     screenshotOnRunFailure: false,
+    retries: {
+        runMode: 2,
+        openMode: 0,
+      },
 })


### PR DESCRIPTION
Retry when cypress failed. We have seen too many cases where flaky cypress passes failed tests after manual retry. This is automated retry offered by cypress. 