### PR TITLE
Update ReadMe deployment notes, add make down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ debug:
 up:
 	docker compose up $(ARGS)
 
+down:
+	docker compose down
+	
 update-dependencies:
 	docker compose run --rm -T ckan /app/ckan/freeze-requirements.sh $(shell id -u) $(shell id -g)
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Copy `vars.yml.template` to `vars.yml`, and customize the values in that file. T
 
 Create the database used by CKAN itself. You have to wait a bit for the datastore DB to be available (see [the cloud.gov instructions on how to know when it's up](https://cloud.gov/docs/services/relational-database/#instance-creation-time)).
 
-    $ cf create-service aws-rds small-psql ${app_name}-db -c '{"version": "11"}'
+    $ cf create-service aws-rds small-psql ${app_name}-db -c '{"version": "12"}'
 
 Create the Redis service for cache
 
@@ -116,7 +116,7 @@ Create the Redis service for cache
 
 Create the SOLR service for data search
 
-    $ cf create-service solr-cloud base ${app_name}-solr -c solr/service-config-${space}.json -b ssb-solr-gsa-datagov-${space}
+    $ cf create-service solr-on-ecs base ${app_name}-solr -c solr/service-config-${space}.json -b "ssb-solrcloud-gsa-datagov-${space}"
 
 Create the secrets service to store secret environment variables. See
 [Secrets](#secrets) below.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Copy `vars.yml.template` to `vars.yml`, and customize the values in that file. T
 
 Create the database used by CKAN itself. You have to wait a bit for the datastore DB to be available (see [the cloud.gov instructions on how to know when it's up](https://cloud.gov/docs/services/relational-database/#instance-creation-time)).
 
-    $ cf create-service aws-rds small-psql ${app_name}-db -c '{"version": "12"}'
+    $ cf create-service aws-rds small-psql ${app_name}-db -c '{"version": "15"}'
 
 Create the Redis service for cache
 


### PR DESCRIPTION
Related to: GSA/data.gov#5053

Changes:
- Updates 2 of the commands in the deployment instructions
    - Updates the "version" of postgres from 11 to 12
    - Updates the command to bring up solr
- Added a `down` command to the make file to make it faster to bring down containers.