### PR TITLE
Only log extension messages at the INFO level

### DIFF
--- a/ckan/setup/ckan.ini
+++ b/ckan/setup/ckan.ini
@@ -350,7 +350,7 @@ qualname = ckan.model
 propagate = 0
 
 [logger_ckanext]
-level = DEBUG
+level = INFO
 handlers = console,consoleerror
 qualname = ckanext
 propagate = 0


### PR DESCRIPTION
The change to `ckanext-geodatagov` didn't stop our loud "Added FQ to collection_package_id" because we were logging `ckanext` at the DEBUG level in `ckan.ini`. This changes that file to log messages from extensions at the `INFO` level.

I pushed this manually to staging and it appears to have stopped the desired messages from making it to New Relic:

![Screenshot 2025-02-18 at 3 01 42 PM](https://github.com/user-attachments/assets/0e03a424-cb98-4ab0-ab7c-8fdae26ef512)
