### PR TITLE
bump to the latest `ckanext-datagovtheme` v`0.2.43`

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.4.1
 ckan @ git+https://github.com/GSA/ckan.git@8c4a517efeac80db098cc6ba144cb742bbeca194
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.1
-ckanext-datagovtheme==0.2.42
+ckanext-datagovtheme==0.2.43
 ckanext-datajson==0.1.27
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@b8ebf24004cd3f3edb7f9d01c87c20259c102093
 ckanext-envvars==0.0.6


### PR DESCRIPTION
Ref: GSA/data.gov#5076

Changes:
- bumps the `ckanext-datagovtheme` to v`0.2.43`

Note:
- Ensure the following is merged before merging this PR: https://github.com/GSA/ckanext-datagovtheme/pull/226 (should be purple)