### PR TITLE
update datajson for DOJ additional fields

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -14,7 +14,7 @@ ckan @ git+https://github.com/GSA/ckan.git@8c4a517efeac80db098cc6ba144cb742bbeca
 -e git+https://github.com/ckan/ckanext-archiver.git@cbfadf9fbf10405958fdef9f77a7faedc05aa20b#egg=ckanext_archiver
 ckanext-datagovcatalog==0.1.1
 ckanext-datagovtheme==0.2.43
-ckanext-datajson==0.1.27
+ckanext-datajson==0.1.28
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@b8ebf24004cd3f3edb7f9d01c87c20259c102093
 ckanext-envvars==0.0.6
 ckanext-geodatagov==0.2.10


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/5124

bump ckanext-datajson version to deal with additional fields that contain `dict` type of data.