### PR TITLE
add webhook-type for slackapi

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -57,6 +57,7 @@ jobs:
         if: ${{ inputs.notification }}
         uses: slackapi/slack-github-action@v2
         with:
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "${{inputs.app}} catalog app in ${{inputs.environ}} space is now in ${{inputs.mode}} mode."


### PR DESCRIPTION
Need `webhook-type: incoming-webhook` for slackapi/slack-github-action@**v2**, according to https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0#the-webhook-type-must-be-specified-in-webhook-inputs