### PR TITLE
removes nginx version from proxy when curl'ed directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ test: clean build
 
 # everytime you added some new variables, you need to swap it with some test values
 # and swap it back after the test. This is because "nginx -t" test cannot read env variables.
+# NOTE: on Mac OS-X you need to install gnu-sed `brew install gnu-sed` and add gnubin to your $PATH
+#		or this will error out b/c Mac uses BSD-sed
 validate-proxy:
 	sed -i 's/{{nameservers}}/127.0.0.1/g' proxy/nginx.conf
 	sed -i 's/{{env "EXTERNAL_ROUTE"}}/127.0.0.2/g' proxy/nginx.conf proxy/nginx-cloudfront.conf

--- a/proxy/nginx-common.conf
+++ b/proxy/nginx-common.conf
@@ -110,3 +110,5 @@ location /maptiles {
   proxy_pass https://tile.openstreetmap.org/;
 }
 
+# Don't leak any server information in response headers
+server_tokens off;


### PR DESCRIPTION
Related to: https://github.com/GSA/data.gov/issues/5152

Removes server version info from proxy response...

previously:
```
(3.10.14) ➜  catalog.data.gov git:(main) ✗ curl https://catalog-dev-datagov.app.cloud.gov                                                                          
<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
<hr><center>nginx/1.27.4</center>
</body>
</html>
```

now:
```
(3.10.14) ➜  catalog.data.gov git:(main) ✗ curl https://catalog-dev-datagov.app.cloud.gov        
<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

to remove the nginx block entirely it is suggested we would need the ngx_headers_more module
https://stackoverflow.com/a/20247497