### PR TITLE
pin to python 3.10.16

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10.16
 
 # Install Dependencies
 # - Download Saxon jar for FGDC2ISO transform (geodatagov)

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.10.x
+python-3.10.16


### PR DESCRIPTION
python released new patch version for 3.10 [yesterday](https://github.com/docker-library/python/commit/70fc099be48e4a130afd949a4dd3c6afe6935b8a). we noticed this error. 

```
python setup.py bdist_wheel did not run successfully.
...
error: invalid command 'bdist_wheel'
```

This will pin the python to `3.10.16`.