### PR TITLE
No pin

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.16
+FROM python:3.10
 
 # Install Dependencies
 # - Download Saxon jar for FGDC2ISO transform (geodatagov)

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.10.16
+python-3.10.x


### PR DESCRIPTION
python quickly patched its breaking changes. 
- https://github.com/docker-library/python/pull/1024

version pin is no longer needed.