### PR TITLE
fix tracking overhead issue for api calls

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -11,7 +11,7 @@ cffi==1.17.1
 chardet==5.2.0
 charset-normalizer==3.4.1
 ckan @ git+https://github.com/GSA/ckan.git@0482ac3a602815c32998904b46e490e4ec6fbfbf
-ckanext-datagovcatalog==0.1.1
+ckanext-datagovcatalog==0.1.3
 ckanext-datagovtheme==0.3.7
 ckanext-datajson==0.1.28
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@b8ebf24004cd3f3edb7f9d01c87c20259c102093


### PR DESCRIPTION
Related issue: https://github.com/GSA/data.gov/issues/5174

Monkey-patch TrackingPlugin.after_dataset_search to skip tracking summary for API calls.
This improves performance for /api/3/action/package_search with large datasets.