### PR TITLE
use latest rust

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -11,9 +11,11 @@ USER root
 RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y curl vim stunnel4 git
 
 # Install EFS Dependencies
-RUN apt-get -y install binutils rustc cargo pkg-config libssl-dev
+RUN apt-get -y install binutils cargo pkg-config libssl-dev
+## get latest rust
+RUN curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
 RUN git clone --depth 1 --branch v2.1.0 https://github.com/aws/efs-utils
-RUN cd efs-utils && ./build-deb.sh && apt-get -y install ./build/amazon-efs-utils*deb
+RUN cd efs-utils && . /root/.cargo/env && ./build-deb.sh && apt-get -y install ./build/amazon-efs-utils*deb
 
 # Install hostname resolution dependencies
 RUN apt-get install -y dnsutils


### PR DESCRIPTION
To addess issue observed in 
- https://github.com/GSA/data.gov/issues/5227#issuecomment-2864272059

EFS requires rustc 1.82.0 or newer. The one comes with ubuntu is 1.75.0.