### PR TITLE
No longer need an SMTP service

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -41,7 +41,6 @@ applications:
       - ((app_name))-redis
       - ((app_name))-secrets
       - ((app_name))-solr
-      - ((app_name))-smtp
       - ((app_name))-s3
       - sysadmin-users
     routes:


### PR DESCRIPTION
Catalog-next no longer has the need to send email, so this takes away the binding to an SMTP service.