### PR TITLE
gunicorn setting to use gthread

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -94,8 +94,6 @@ zope.interface==6.4post2
 # Pinned greenlet version to match version delivered with OS,
 # preventing error with gevent dependency using newer version.
 gunicorn
-eventlet
-# greenlet==0.4.12
 
 # New Relic
 newrelic

--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -28,7 +28,6 @@ defusedxml==0.7.1
 dnspython==2.7.0
 dominate==2.9.1
 elementpath==5.0.0
-eventlet==0.39.1
 feedgen @ git+https://github.com/GSA/python-feedgen.git@b1fe34a7e14ebdaf6f415cdee5855c3c77305f16
 Flask==3.0.3
 flask-babel==4.0.0

--- a/ckan/setup/server_start.sh
+++ b/ckan/setup/server_start.sh
@@ -12,5 +12,16 @@ DIR="$(dirname "${BASH_SOURCE[0]}")"
 if [[ "$CKAN_SITE_URL" = "http://ckan:5000" ]]; then
   exec newrelic-admin run-program gunicorn "wsgi:application" --config "$DIR/gunicorn.conf.py" -b "0.0.0.0:$PORT" --chdir $DIR  --timeout 120 --workers 2
 else
-  exec newrelic-admin run-program gunicorn "wsgi:application" --config "$DIR/gunicorn.conf.py" -b "0.0.0.0:$PORT" --chdir $DIR  --timeout 120 --worker-class eventlet --workers 4 --threads 4 --forwarded-allow-ips='*'
+  exec newrelic-admin run-program gunicorn "wsgi:application" \
+  --config "$DIR/gunicorn.conf.py" \
+  -b "0.0.0.0:$PORT" \
+  --chdir $DIR  \
+  --timeout 30 \
+  --worker-class gthread \
+  --workers 3 \
+  --threads 4 \
+  --max-requests 1000 \
+  --max-requests-jitter 100 \
+  --preload \
+  --forwarded-allow-ips='*'
 fi

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -5,7 +5,7 @@ space_name: prod
 ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-prod-catalog
 ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.production.idp.xml
 
-web-instances: 3
+web-instances: 5
 admin-instances: 1
 gather-instances: 1
 fetch-instances: 3


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/5263

- Changed worker type from eventlet to gthread for better handling large xml loading
- Changed worker number from 4 to 3 to give each worker more memory

This change was manually pushed to prod:catalog-web at `2025-06-02 18:09:49 ET`. Will compare the app performance before and after before merging it. 
