### PR TITLE
add nginx-basicauth.conf

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -83,3 +83,4 @@ applications:
       EXTERNAL_ROUTE_ADMIN: ((route-external-admin))
       INTERNAL_ROUTE_ADMIN: ((route-internal-admin))
       DENY_PACKAGE_CREATE: ((deny_package_create))
+      ENABLE_BASIC_AUTH: ((enable_basic_auth))

--- a/proxy/.profile
+++ b/proxy/.profile
@@ -18,6 +18,19 @@ export SPACE_NAME
 
 echo "Setting up proxy in $APP_NAME on $SPACE_NAME"
 
+# basic auth
+if [ "$ENABLE_BASIC_AUTH" = "true" ]; then
+    echo "Setting up basic authentication"
+    HTPASSWD_CONTENT=$(vcap_get_service secrets .credentials.htpasswd_content)
+    if [ "$HTPASSWD_CONTENT" != "null" ] && [ -n "$HTPASSWD_CONTENT" ]; then
+        mkdir -p ./nginx-auth || true
+        echo "$HTPASSWD_CONTENT" > ./nginx-auth/.htpasswd
+        echo "Basic auth file created successfully at ./nginx-auth/.htpasswd"
+    else
+        echo "Warning: ENABLE_BASIC_AUTH is true but no secrets service found or htpasswd_content is empty"
+    fi
+fi
+
 # sitemap config
 # url constructed in nginx conf
 # the jankiness and shame of this is immeasurable

--- a/proxy/nginx-basicauth.conf
+++ b/proxy/nginx-basicauth.conf
@@ -1,0 +1,12 @@
+    # Conditional Basic Authentication
+    set $enable_auth '{{env "ENABLE_BASIC_AUTH"}}';
+    set $auth_realm "off";
+    set $auth_file "off";
+    
+    if ($enable_auth = "true") {
+      set $auth_realm "Restricted Access";
+      set $auth_file ./nginx-auth/.htpasswd;
+    }
+    
+    auth_basic $auth_realm;
+    auth_basic_user_file $auth_file;

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -35,6 +35,7 @@ http {
   server {
     server_name {{env "EXTERNAL_ROUTE"}};
 
+    include nginx-basicauth.conf;
     include nginx-cloudfront.conf;
     include nginx-badbot403.conf;
     include nginx-goodbot200.conf;

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -2,6 +2,8 @@
 app_name: catalog-next
 space_name: development
 
+enable_basic_auth: false
+
 ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-next-dev-catalog
 ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.sandbox.idp.xml
 

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -2,6 +2,8 @@
 app_name: catalog-next
 space_name: staging
 
+enable_basic_auth: true
+
 ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-next-stage-catalog
 ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.sandbox.idp.xml
 


### PR DESCRIPTION
Adding basic auth on staging:catalog-next-web instance.
 
Basic auth was added to staging:catalog-web instance via cloudfront. Not sure why. Adding basic auth to nginx is more convenient, can be turn on/off with one variable, and works for both scenario regardless the app is behind cloudfront or not. catalog-web is behind cloudfront, catalog-next-web is not yet behind cloudfront.
