### PR TITLE
use 1 catalog-fetch instance

### DIFF
--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -8,7 +8,7 @@ ckanext__saml2auth__idp_metadata__local_path: ckan/setup/login.production.idp.xm
 web-instances: 5
 admin-instances: 1
 gather-instances: 1
-fetch-instances: 3
+fetch-instances: 1
 proxy-instances: 2
 memory_quota: 800M
 gather_memory_quota: 3G


### PR DESCRIPTION
As mentioned in 
- https://github.com/GSA/data.gov/issues/5296#issuecomment-3032532692

1 instance is enough to finish all harvest jobs. it is slower than 3 instances, but it might eliminate the duplication during harvesting. 