### PR TITLE
add 403 forbidden html

### DIFF
--- a/proxy/nginx-common.conf
+++ b/proxy/nginx-common.conf
@@ -84,6 +84,12 @@ error_page 500 502 504 /500.html;
 location = /500.html {
   root ./public;
 }
+
+error_page 403 /403.html;
+location = /403.html {
+  root ./public;
+}
+
 # NGINX searches for a URI that starts with /static-assets/ in the ./public/static-assets/ directory
 location /static-assets/ {}
 

--- a/proxy/nginx-malicious.conf
+++ b/proxy/nginx-malicious.conf
@@ -4,12 +4,11 @@
 if ($http_x_amzn_waf_detection = "malicious") {
   return 429;
 }
-error_page 429 @malicious;
-
 if ($http_x_amzn_waf_detection = "datacenter") {
-  return 403;
+  return 429;
 }
-error_page 403 @malicious;
+
+error_page 429 @malicious;
 
 location @malicious {
   rewrite ^(.*)$ /malicious.html break;

--- a/proxy/public/403.html
+++ b/proxy/public/403.html
@@ -1,11 +1,10 @@
-
 <!DOCTYPE html>
 <!--[if IE 9]> <html lang="en" class="ie9"> <![endif]-->
 <!--[if gt IE 8]><!--> <html lang="en"  > <!--<![endif]-->
   <head>
       <meta name="generator" content="ckan 2.10.5" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>500 Web server unavailable</title>
+    <title>403 Forbidden</title>
 
     
     
@@ -217,9 +216,11 @@
   <article class="module">
     <div class="module-content">
       
-      <h1>500 Web server unavailable 😵</h1>
+      <h1>403 Forbidden</h1>
       
-      Please contact datagovhelp@gsa.gov for assistance.
+      You don't have permission to access this resource.
+      <br><br>
+      If you believe this is an error, Please contact datagovhelp@gsa.gov for assistance.
     </div>
     
     
@@ -397,4 +398,4 @@
 <script src="/static-assets/js/8c3c143a_jquery.js" type="text/javascript"></script>
 <script src="/static-assets/js/extension.js" type="text/javascript"></script>
   </body>
-</html>
+</html> 


### PR DESCRIPTION
When user is accessing a forbidden resource and see 403 response code, we want to display a forbidden message

- created 403.html, using same html template as 500.html and malicious.html
- 403 error sees 403.html; 429 sees malicious.html. 