### PR TITLE
new domain names for h20

### DIFF
--- a/proxy/public/robots.txt
+++ b/proxy/public/robots.txt
@@ -1,9 +1,2 @@
 User-agent: *
-Disallow: /dataset/rate/
-Disallow: /revision/
-Disallow: /dataset/*/history
-Disallow: /api/
-Crawl-Delay: 10
-
-# sitemap url should get replaced by proxy .profile
-Sitemap: https://catalog.data.gov/sitemap.xml
+Disallow: /

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -13,8 +13,8 @@ memory_quota: 800M
 new_relic_monitor_mode: true
 
 # use CDN domain for route-public if available, otherwise use route-external
-route-public: catalog-next-prod-datagov.app.cloud.gov
-route-external: catalog-next-prod-datagov.app.cloud.gov
+route-public: catalog-beta.data.gov
+route-external: catalog-beta.data.gov
 route-internal: catalog-next-prod-datagov.apps.internal
 route-external-admin: catalog-next-prod-admin-datagov.app.cloud.gov
 route-internal-admin: catalog-next-prod-admin-datagov.apps.internal
@@ -59,6 +59,6 @@ saml2_certificate: |
 
 googleanalytics_id: UA-00000000-6
 
-enable_basic_auth: true
+enable_basic_auth: false
 
-harvest_admin_url: https://datagov-harvest.app.cloud.gov/
+harvest_admin_url: https://harvest.data.gov

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -63,4 +63,4 @@ googleanalytics_id: UA-00000000-5
 
 enable_basic_auth: true
 
-harvest_admin_url: https://datagov-harvest-staging.app.cloud.gov/
+harvest_admin_url: https://datagov-harvest-staging.app.cloud.gov


### PR DESCRIPTION
For
- https://github.com/GSA/data.gov/issues/5344

Changes:
- use `catalog-beta.data.gov` for prod catalog-next
- use `harvest.data.gov` for the admin url
- update `robots.txt` to disallow all crawlers
- disable basic auth on prod catalog-next