### PR TITLE
add 2 snyk exceptions

### DIFF
--- a/ckan/.snyk
+++ b/ckan/.snyk
@@ -2,3 +2,12 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 patch: {}
+ignore:
+  SNYK-DEBIAN12-ZLIB-6008963:
+    - '*':
+        reason: "python:3.10-slim is on Debian 13 (Trixie), not Debian 12"
+        expires: "2099-12-31T23:59:59Z"
+  SNYK-DEBIAN12-PAM-10378969:
+    - '*':
+        reason: "python:3.10-slim is on Debian 13 (Trixie), not Debian 12"
+        expires: "2099-12-31T23:59:59Z"


### PR DESCRIPTION
Ignore:
SNYK-DEBIAN12-ZLIB-6008963
SNYK-DEBIAN12-PAM-10378969

snyk assumes our docker image `python:3.10-slim` is on Debian 12. It is actually Debian 13 (trixie)

```
$ docker run --rm python:3.10-slim cat /etc/os-release | grep Debian

PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
NAME="Debian GNU/Linux"
```