### PR TITLE
Pin CKAN extensions

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -6,10 +6,10 @@ git+https://github.com/ckan/ckanext-dcat@v1.7.0#egg=ckanext-dcat
 git+https://github.com/GSA/ckanext-saml2auth.git@ckan-2-11-datagov#egg=ckanext-saml2auth
 
 ckanext-datagovcatalog
-ckanext-datagovtheme
+ckanext-datagovtheme<0.4.0
 ckanext-datajson
 ckanext-envvars>=0.0.3
-ckanext-geodatagov
+ckanext-geodatagov<0.4.0
 ckanext-metrics-dashboard
 
 # Pin for saml2auth to work


### PR DESCRIPTION
Make sure ckan extensions don't use latest version prepared for catalog-beta. Should have no material change, just making sure no catalog-beta changes are applied to catalog with upgrade process.