### PR TITLE
update Werkzeug in requirements.in for snyk

### DIFF
--- a/ckan/requirements.in
+++ b/ckan/requirements.in
@@ -83,7 +83,7 @@ sqlparse==0.5.4
 typing_extensions==4.12.2
 tzlocal==5.2
 webassets==2.0
-Werkzeug[watchdog]==3.1.4
+Werkzeug[watchdog]==3.1.5
 zope.interface==6.4post2
 
 # we are running under gunicorn


### PR DESCRIPTION
snyk complains Werkzeug 3.1.4 in the requirements.in file, even requirements.txt is fine. We might want to change snyk behavior. 