### PR TITLE
Update To New Old Catalog User Guide URL (Merge On Cutover)

### DIFF
--- a/ckan/requirements.txt
+++ b/ckan/requirements.txt
@@ -13,7 +13,7 @@ chardet==7.1.0
 charset-normalizer==3.4.6
 ckan @ git+https://github.com/GSA/ckan.git@cf93bfa00f413015ed614b0e0fd85be33f2d72d9
 ckanext-datagovcatalog==0.1.3
-ckanext-datagovtheme==0.3.9
+ckanext-datagovtheme==0.3.10
 ckanext-datajson==0.1.28
 ckanext-dcat @ git+https://github.com/ckan/ckanext-dcat@255fcf1352273f9be98e9f02a5198efc4790c94e
 ckanext-envvars==0.0.6

--- a/proxy/public/403.html
+++ b/proxy/public/403.html
@@ -131,7 +131,7 @@
                                 <a class="usa-nav__link" href="https://data.gov/contact/"><span class="text-uppercase">Contact</span></a>
                             </li>
                             <li class="usa-nav__primary-item desktop-hide">
-                                <a class="usa-nav__link" href="https://data.gov/user-guide/"><span class="text-uppercase">User Guide</span></a>
+                                <a class="usa-nav__link" href="https://data.gov/old-user-guide/"><span class="text-uppercase">User Guide</span></a>
                             </li>
                         </ul>
                         <div class="usa-nav__secondary">
@@ -142,7 +142,7 @@
                 </nav>
             </div>
             <div class="grid-col-auto user-guide__col desktop-show text-center">
-                <a href="https://data.gov/user-guide/">
+                <a href="https://data.gov/old-user-guide/">
                     <img src="/static-assets/images/user-guide.svg" alt="User Guide" />
                     <div class="user-guide__text">User Guide</div>
                 </a>

--- a/proxy/public/500.html
+++ b/proxy/public/500.html
@@ -132,7 +132,7 @@
                                 <a class="usa-nav__link" href="https://data.gov/contact/"><span class="text-uppercase">Contact</span></a>
                             </li>
                             <li class="usa-nav__primary-item desktop-hide">
-                                <a class="usa-nav__link" href="https://data.gov/user-guide/"><span class="text-uppercase">User Guide</span></a>
+                                <a class="usa-nav__link" href="https://data.gov/old-user-guide/"><span class="text-uppercase">User Guide</span></a>
                             </li>
                         </ul>
                         <div class="usa-nav__secondary">
@@ -143,7 +143,7 @@
                 </nav>
             </div>
             <div class="grid-col-auto user-guide__col desktop-show text-center">
-                <a href="https://data.gov/user-guide/">
+                <a href="https://data.gov/old-user-guide/">
                     <img src="/static-assets/images/user-guide.svg" alt="User Guide" />
                     <div class="user-guide__text">User Guide</div>
                 </a>

--- a/proxy/public/maintenance.html
+++ b/proxy/public/maintenance.html
@@ -132,7 +132,7 @@
                                 <a class="usa-nav__link" href="https://data.gov/contact/"><span class="text-uppercase">Contact</span></a>
                             </li>
                             <li class="usa-nav__primary-item desktop-hide">
-                                <a class="usa-nav__link" href="https://data.gov/user-guide/"><span class="text-uppercase">User Guide</span></a>
+                                <a class="usa-nav__link" href="https://data.gov/old-user-guide/"><span class="text-uppercase">User Guide</span></a>
                             </li>
                         </ul>
                         <div class="usa-nav__secondary">
@@ -143,7 +143,7 @@
                 </nav>
             </div>
             <div class="grid-col-auto user-guide__col desktop-show text-center">
-                <a href="https://data.gov/user-guide/">
+                <a href="https://data.gov/old-user-guide/">
                     <img src="/static-assets/images/user-guide.svg" alt="User Guide" />
                     <div class="user-guide__text">User Guide</div>
                 </a>

--- a/proxy/public/malicious.html
+++ b/proxy/public/malicious.html
@@ -132,7 +132,7 @@
                                 <a class="usa-nav__link" href="https://data.gov/contact/"><span class="text-uppercase">Contact</span></a>
                             </li>
                             <li class="usa-nav__primary-item desktop-hide">
-                                <a class="usa-nav__link" href="https://data.gov/user-guide/"><span class="text-uppercase">User Guide</span></a>
+                                <a class="usa-nav__link" href="https://data.gov/old-user-guide/"><span class="text-uppercase">User Guide</span></a>
                             </li>
                         </ul>
                         <div class="usa-nav__secondary">
@@ -143,7 +143,7 @@
                 </nav>
             </div>
             <div class="grid-col-auto user-guide__col desktop-show text-center">
-                <a href="https://data.gov/user-guide/">
+                <a href="https://data.gov/old-user-guide/">
                     <img src="/static-assets/images/user-guide.svg" alt="User Guide" />
                     <div class="user-guide__text">User Guide</div>
                 </a>

--- a/proxy/public/sitedown.html
+++ b/proxy/public/sitedown.html
@@ -132,7 +132,7 @@
                                 <a class="usa-nav__link" href="https://data.gov/contact/"><span class="text-uppercase">Contact</span></a>
                             </li>
                             <li class="usa-nav__primary-item desktop-hide">
-                                <a class="usa-nav__link" href="https://data.gov/user-guide/"><span class="text-uppercase">User Guide</span></a>
+                                <a class="usa-nav__link" href="https://data.gov/old-user-guide/"><span class="text-uppercase">User Guide</span></a>
                             </li>
                         </ul>
                         <div class="usa-nav__secondary">
@@ -143,7 +143,7 @@
                 </nav>
             </div>
             <div class="grid-col-auto user-guide__col desktop-show text-center">
-                <a href="https://data.gov/user-guide/">
+                <a href="https://data.gov/old-user-guide/">
                     <img src="/static-assets/images/user-guide.svg" alt="User Guide" />
                     <div class="user-guide__text">User Guide</div>
                 </a>

--- a/proxy/public/template.html
+++ b/proxy/public/template.html
@@ -132,7 +132,7 @@
                                 <a class="usa-nav__link" href="https://data.gov/contact/"><span class="text-uppercase">Contact</span></a>
                             </li>
                             <li class="usa-nav__primary-item desktop-hide">
-                                <a class="usa-nav__link" href="https://data.gov/user-guide/"><span class="text-uppercase">User Guide</span></a>
+                                <a class="usa-nav__link" href="https://data.gov/old-user-guide/"><span class="text-uppercase">User Guide</span></a>
                             </li>
                         </ul>
                         <div class="usa-nav__secondary">
@@ -143,7 +143,7 @@
                 </nav>
             </div>
             <div class="grid-col-auto user-guide__col desktop-show text-center">
-                <a href="https://data.gov/user-guide/">
+                <a href="https://data.gov/old-user-guide/">
                     <img src="/static-assets/images/user-guide.svg" alt="User Guide" />
                     <div class="user-guide__text">User Guide</div>
                 </a>


### PR DESCRIPTION
Ticket: GSA/data.gov#5826

- Switches out references from the current catalog to old catalog user guide URL 